### PR TITLE
fix(agent): rescatar los mensajes que quedan varados por una alarma perdida

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -171,7 +171,15 @@ export class SupportAgent extends Agent<Env, SupportAgentState> {
     // cf_agents_schedules table, so raw ctx.storage.setAlarm() alone won't
     // invoke our code. We upsert a fixed 'msg-buffer' row (so rapid messages
     // debounce to a single fire) and set the raw alarm as the trigger.
-    const alarmAt = Date.now() + cfg.bufferMs;
+    // Rescue for stranded messages: a Cloudflare alarm can silently fail to
+    // fire. When that happens the customer's message sits in the buffer until
+    // they write again — we saw a real customer wait 11 minutes before typing
+    // "Hola?". If the oldest buffered message is already older than 2x the
+    // normal wait, don't wait a whole buffer window again: process almost
+    // immediately.
+    const oldestAt = pending[0]?.receivedAt ?? Date.now();
+    const hasStranded = Date.now() - oldestAt > cfg.bufferMs * 2;
+    const alarmAt = Date.now() + (hasStranded ? 500 : cfg.bufferMs);
     const alarmAtSec = Math.floor(alarmAt / 1000);
     this.sql`
       INSERT OR REPLACE INTO cf_agents_schedules
@@ -180,6 +188,12 @@ export class SupportAgent extends Agent<Env, SupportAgentState> {
         ('msg-buffer', 'processBuffer', '{}', 'delayed', ${alarmAtSec}, unixepoch())
     `;
     await this.ctx.storage.setAlarm(alarmAt);
+    // Cheap guard against the lost alarm: if it didn't get registered, retry
+    // once and leave a trace in the log.
+    if ((await this.ctx.storage.getAlarm()) === null) {
+      console.error("[ingest] alarm was not armed — retrying");
+      await this.ctx.storage.setAlarm(alarmAt);
+    }
     this.setState({ ...this.state, lastAlarmAt: alarmAt });
 
     return { acknowledged: true };

--- a/test/agent.media.test.ts
+++ b/test/agent.media.test.ts
@@ -372,4 +372,41 @@ describe("SupportAgent.ingest — bot_paused (settings)", () => {
 
     expect(storage.setAlarm).toHaveBeenCalledTimes(1);
   });
+
+  it("re-arms the alarm when it did not get registered", async () => {
+    stubSettings();
+    const { agent, storage } = makeAgent({ tier: "free" });
+    stubConversations();
+    // The platform silently dropped the alarm: nothing is armed afterwards.
+    storage.getAlarm.mockResolvedValue(null);
+
+    await agent.ingest({
+      channel: "telegram",
+      channelUserId: "u1",
+      text: "hola",
+    });
+
+    expect(storage.setAlarm).toHaveBeenCalledTimes(2);
+  });
+
+  it("processes almost immediately when a buffered message is stranded", async () => {
+    stubSettings();
+    const { agent, storage } = makeAgent({ tier: "free" });
+    stubConversations();
+    // A previous message never got processed because its alarm was lost.
+    agent.setState({
+      ...agent.state,
+      pendingMessages: [{ text: "hola", receivedAt: Date.now() - 600_000 }],
+    });
+
+    const before = Date.now();
+    await agent.ingest({
+      channel: "telegram",
+      channelUserId: "u1",
+      text: "hola?",
+    });
+
+    const alarmAt = storage.setAlarm.mock.calls[0][0];
+    expect(alarmAt - before).toBeLessThan(2_000);
+  });
 });


### PR DESCRIPTION
## El problema

Una alarma de un Durable Object puede fallar en silencio y no dispararse. Cuando pasa, el mensaje del cliente se queda en `pendingMessages` y solo se procesa la próxima vez que la persona escribe.

Nos pasó en producción el **29/07/2026**: un cliente escribió, esperó **11 minutos** sin respuesta, y el bot solo reaccionó cuando volvió a escribir "Hola?". Desde fuera el bot parecía estar bien.

En `main` sigue así:

```ts
const alarmAt = Date.now() + cfg.bufferMs;
```

No hay rescate para el mensaje varado, y no se comprueba que la alarma haya quedado armada.

## Qué hace este PR

Dos defensas baratas dentro de `ingest()`:

1. **Rescate del mensaje varado.** Si el más viejo del buffer ya lleva más de 2× la espera normal, se programa casi de inmediato (500 ms) en vez de esperar otra ventana completa de buffer.
2. **Verificación de la alarma.** Después de armarla se comprueba que quedó registrada. Si no, se reintenta una vez y queda rastro en el log.

Las dos son no-ops en el camino feliz: si la alarma funciona, el comportamiento no cambia en nada.

## Pruebas

Dos casos nuevos en `test/agent.media.test.ts`, sobre el banco de pruebas que ya existía:

- `re-arms the alarm when it did not get registered`
- `processes almost immediately when a buffered message is stranded`

`pnpm typecheck` limpio y las **437 pruebas** del repo en verde con el cambio aplicado.

## Contexto

Somos [Escuela Con Confianza](https://escuelaconconfianza.com), una escuela de terapia para la tartamudez en Lima. Corremos Forja en producción desde julio y esto lo encontramos atendiendo clientes reales.

Este es el primero de varios: tenemos otros dos arreglos de core listos (los mensajes que se pierden al pausar el bot, y el token de Telegram que queda guardado en la base de datos). Van en PRs aparte, siguiendo la regla de un PR por tema.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved processing of delayed or stranded buffered messages.
  - Added alarm recovery to help ensure queued messages are processed reliably.
  - Long-delayed messages are now scheduled for near-immediate processing.

- **Tests**
  - Added regression coverage for alarm recovery and delayed message processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->