### PR TITLE
fix(agent): registrar el mensaje del cliente cuando el bot esta en pausa

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -80,8 +80,22 @@ export class SupportAgent extends Agent<Env, SupportAgentState> {
       return { acknowledged: true };
     }
 
-    // If paused, ignore (bot stays silent)
+    // Media is processed BEFORE the pause checks on purpose: a paused
+    // conversation still has to leave the customer's message in the panel, and
+    // it has to be readable there — the transcript of a voice note, not
+    // "(audio)".
+    const { processedText, hasImage } = await this.processMedia(payload);
+
+    // Conversation paused (a human took over): the bot stays silent, but the
+    // customer's message MUST still be recorded. Otherwise it never shows up in
+    // the dashboard and the team has no way to see what it is supposed to
+    // answer by hand — which is the whole point of pausing.
+    //
+    // Seen in production on 2026-07-29: a teammate replied from his own phone
+    // while the conversation was paused and his message never reached the
+    // dashboard.
     if (await convs.isPaused(conv.id)) {
+      await this.recordWithoutReplying(db, conv.id, processedText);
       return { acknowledged: true };
     }
 
@@ -116,7 +130,61 @@ export class SupportAgent extends Agent<Env, SupportAgentState> {
       }
     }
 
-    // Process media (audio → transcription, image → Pro-gated multimodal marker)
+    // Append to buffer (we always persist the client's message)
+    const pending = [
+      ...this.state.pendingMessages,
+      { text: processedText, receivedAt: Date.now() },
+    ];
+    this.setState({
+      ...this.state,
+      pendingMessages: pending,
+      imageRetryCount: hasImage ? 0 : this.state.imageRetryCount,
+    });
+
+    // Resolve effective config (D1 settings overlaid on env defaults).
+    // We need at least bot_paused (to decide whether to reply) and the buffer.
+    const cfg = await resolveAgentConfig(this.env, []);
+
+    // Owner paused the bot via the dashboard → keep the message buffered but
+    // stay silent: do NOT arm the alarm, so alarm() never runs.
+    //
+    // Same hole as the per-conversation pause: the message only lived in
+    // pendingMessages (Durable Object state), which the dashboard cannot see,
+    // so the owner had no way to read what came in while the bot was off. It
+    // stays buffered (unchanged) and is now recorded too.
+    if (cfg.botPaused) {
+      await this.recordWithoutReplying(db, conv.id, processedText);
+      return { acknowledged: true };
+    }
+
+    // Schedule buffer processing via the agents SDK scheduler.
+    // The SDK overrides alarm() to dispatch named callbacks from its
+    // cf_agents_schedules table, so raw ctx.storage.setAlarm() alone won't
+    // invoke our code. We upsert a fixed 'msg-buffer' row (so rapid messages
+    // debounce to a single fire) and set the raw alarm as the trigger.
+    const alarmAt = Date.now() + cfg.bufferMs;
+    const alarmAtSec = Math.floor(alarmAt / 1000);
+    this.sql`
+      INSERT OR REPLACE INTO cf_agents_schedules
+        (id, callback, payload, type, time, created_at)
+      VALUES
+        ('msg-buffer', 'processBuffer', '{}', 'delayed', ${alarmAtSec}, unixepoch())
+    `;
+    await this.ctx.storage.setAlarm(alarmAt);
+    this.setState({ ...this.state, lastAlarmAt: alarmAt });
+
+    return { acknowledged: true };
+  }
+
+  /**
+   * Audio → transcription, image → Pro-gated multimodal marker.
+   *
+   * Extracted from ingest() so the paused paths can record a READABLE message:
+   * the transcript of the voice note, not a placeholder.
+   */
+  private async processMedia(
+    payload: AgentIncomingPayload,
+  ): Promise<{ processedText: string; hasImage: boolean }> {
     let processedText = payload.text ?? "";
     let hasImage = false;
 
@@ -145,44 +213,27 @@ export class SupportAgent extends Agent<Env, SupportAgentState> {
       }
     }
 
-    // Append to buffer (we always persist the client's message)
-    const pending = [
-      ...this.state.pendingMessages,
-      { text: processedText, receivedAt: Date.now() },
-    ];
-    this.setState({
-      ...this.state,
-      pendingMessages: pending,
-      imageRetryCount: hasImage ? 0 : this.state.imageRetryCount,
-    });
+    return { processedText, hasImage };
+  }
 
-    // Resolve effective config (D1 settings overlaid on env defaults).
-    // We need at least bot_paused (to decide whether to reply) and the buffer.
-    const cfg = await resolveAgentConfig(this.env, []);
-
-    // Owner paused the bot via the dashboard → keep the message buffered but
-    // stay silent: do NOT arm the alarm, so alarm() never runs.
-    if (cfg.botPaused) {
-      return { acknowledged: true };
+  /**
+   * The bot is not going to answer this one, but the customer's message still
+   * has to end up in the dashboard so a human can pick it up.
+   *
+   * Best-effort on purpose: if D1 hiccups, the webhook must not fail — losing
+   * the record is bad, returning an error to the channel is worse.
+   */
+  private async recordWithoutReplying(
+    db: Db,
+    conversationId: string,
+    text: string,
+  ): Promise<void> {
+    if (!text.trim()) return;
+    try {
+      await new MessagesRepo(db).append(conversationId, "user", text);
+    } catch (e) {
+      console.error("[ingest] could not record the message while paused:", e);
     }
-
-    // Schedule buffer processing via the agents SDK scheduler.
-    // The SDK overrides alarm() to dispatch named callbacks from its
-    // cf_agents_schedules table, so raw ctx.storage.setAlarm() alone won't
-    // invoke our code. We upsert a fixed 'msg-buffer' row (so rapid messages
-    // debounce to a single fire) and set the raw alarm as the trigger.
-    const alarmAt = Date.now() + cfg.bufferMs;
-    const alarmAtSec = Math.floor(alarmAt / 1000);
-    this.sql`
-      INSERT OR REPLACE INTO cf_agents_schedules
-        (id, callback, payload, type, time, created_at)
-      VALUES
-        ('msg-buffer', 'processBuffer', '{}', 'delayed', ${alarmAtSec}, unixepoch())
-    `;
-    await this.ctx.storage.setAlarm(alarmAt);
-    this.setState({ ...this.state, lastAlarmAt: alarmAt });
-
-    return { acknowledged: true };
   }
 
   /**

--- a/test/agent.media.test.ts
+++ b/test/agent.media.test.ts
@@ -359,6 +359,67 @@ describe("SupportAgent.ingest — bot_paused (settings)", () => {
     expect(storage.setAlarm).not.toHaveBeenCalled();
   });
 
+  it("records the customer message when bot_paused=1, so the team can see it", async () => {
+    stubSettings({ bot_paused: "1" });
+    const { agent } = makeAgent({ tier: "free" });
+    stubConversations();
+    const append = vi
+      .spyOn(MessagesRepo.prototype, "append")
+      .mockResolvedValue(undefined as any);
+
+    await agent.ingest({
+      channel: "telegram",
+      channelUserId: "u1",
+      text: "hola, hay alguien?",
+    });
+
+    expect(append).toHaveBeenCalledWith("conv-1", "user", "hola, hay alguien?");
+    // El buffer no se toca: sigue igual que antes de este arreglo.
+    expect(agent.state.pendingMessages).toHaveLength(1);
+  });
+
+  it("records the customer message when the conversation is paused", async () => {
+    stubSettings();
+    const { agent, storage } = makeAgent({ tier: "free" });
+    stubConversations({ paused: true });
+    const append = vi
+      .spyOn(MessagesRepo.prototype, "append")
+      .mockResolvedValue(undefined as any);
+
+    await agent.ingest({
+      channel: "telegram",
+      channelUserId: "u1",
+      text: "sigo esperando",
+    });
+
+    expect(append).toHaveBeenCalledWith("conv-1", "user", "sigo esperando");
+    // El bot sigue callado.
+    expect(storage.setAlarm).not.toHaveBeenCalled();
+  });
+
+  it("records the voice note as text while paused, not as an empty message", async () => {
+    stubSettings();
+    const { agent } = makeAgent({ tier: "free", aiText: "hola desde un audio" });
+    stubConversations({ paused: true });
+    const append = vi
+      .spyOn(MessagesRepo.prototype, "append")
+      .mockResolvedValue(undefined as any);
+
+    await agent.ingest({
+      channel: "telegram",
+      channelUserId: "u1",
+      audioUrl: "https://example.com/voice.ogg",
+    });
+
+    // Media runs BEFORE the pause check, so what lands in the dashboard is
+    // readable text and not an empty row.
+    expect(append).toHaveBeenCalledTimes(1);
+    const [convId, role, text] = append.mock.calls[0];
+    expect(convId).toBe("conv-1");
+    expect(role).toBe("user");
+    expect(String(text).length).toBeGreaterThan(0);
+  });
+
   it("arms the alarm when bot is not paused", async () => {
     stubSettings();
     const { agent, storage } = makeAgent({ tier: "free" });


### PR DESCRIPTION
## El problema

Pausar el bot es lo que hace el dueño cuando quiere contestar a mano. Pero **el mensaje que motivó la pausa nunca llegaba al panel**, así que no había nada que contestar.

Nos pasó en producción el **29/07/2026**: un compañero del equipo respondió desde su propio teléfono con la conversación pausada, y su mensaje no apareció nunca en la plataforma. Lo descubrimos por casualidad.

Son dos caminos con el mismo agujero:

**1. Conversación pausada** (un humano tomó el control). `ingest()` sale justo después del `isPaused()`, antes de persistir nada:

```ts
// If paused, ignore (bot stays silent)
if (await convs.isPaused(conv.id)) {
  return { acknowledged: true };
}
```

**2. Bot apagado desde el panel.** Ahí el mensaje sí queda, pero solo en `pendingMessages`, que es estado del Durable Object. El panel no lo puede leer.

## Qué hace este PR

Registra el mensaje del cliente en los dos casos. El bot sigue callado, que es lo que se le pidió.

- El procesamiento de media sube por encima de los chequeos de pausa, para que lo que quede en el panel sea **legible**: la transcripción de la nota de voz, no una fila vacía. Se extrajo a `processMedia()`; en el camino normal el comportamiento no cambia.
- El registro es best-effort: si D1 falla, el webhook igual responde 200. Perder el registro es malo; hacer fallar el webhook del canal es peor.
- **El buffer del camino `bot_paused` se deja intacto a propósito**, con su test como estaba. Vaciarlo era tentador, pero es otro tema y otro PR.

## Pruebas

Tres casos nuevos en `test/agent.media.test.ts`, sobre el banco que ya existía:

- `records the customer message when bot_paused=1, so the team can see it`
- `records the customer message when the conversation is paused`
- `records the voice note as text while paused, not as an empty message`

**440 pruebas pasan** (eran 437) y `tsc --noEmit` limpio.

## Contexto

Somos [Escuela Con Confianza](https://escuelaconconfianza.com), una escuela de terapia para la tartamudez en Lima. Corremos Forja en producción desde julio y esto salió atendiendo clientes reales.

Es el segundo de tres. El primero es #6 (la alarma perdida del buffer). El tercero es de seguridad y va aparte.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Incoming customer messages are now recorded in the dashboard even when the bot or conversation is paused.
  * Voice messages received during pauses are transcribed and saved as readable text.
  * Paused conversations continue to avoid triggering automated replies or alarms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->