### PR TITLE
fix(telegram): dejar de guardar el token del bot en la base de datos

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -18,6 +18,7 @@ import { CustomerFactsRepo } from "./db/facts";
 import { createModel } from "./llm/provider";
 import { costOfUsage } from "./pricing";
 import type { ChannelId } from "./channels/shared";
+import { maskTelegramToken, unmaskTelegramToken } from "./telegramFiles";
 
 export interface SupportAgentState {
   conversationId: string | null;
@@ -141,7 +142,10 @@ export class SupportAgent extends Agent<Env, SupportAgentState> {
       } else {
         processedText =
           (processedText || "(imagen sin caption)") +
-          `\n[IMAGE_URL: ${payload.imageUrl}]`;
+          // MASKED: a Telegram file URL carries the bot token inside, and this
+          // marker gets persisted in D1 (and shown in the dashboard, and
+          // included in exports). See src/telegramFiles.ts.
+          `\n[IMAGE_URL: ${maskTelegramToken(payload.imageUrl)}]`;
       }
     }
 
@@ -227,7 +231,12 @@ export class SupportAgent extends Agent<Env, SupportAgentState> {
     if (lastUserMsg) {
       const imgMatch = lastUserMsg.content.match(/\[IMAGE_URL: (.+?)\]/);
       if (imgMatch && isPro(this.env)) {
-        const imageUrl = imgMatch[1];
+        // The token was masked before storing; it goes back in only here, to
+        // fetch the file. It never leaves this call.
+        const imageUrl = unmaskTelegramToken(
+          imgMatch[1],
+          this.env.TELEGRAM_BOT_TOKEN,
+        );
         const cleanText = lastUserMsg.content
           .replace(/\n?\[IMAGE_URL: .+?\]/, "")
           .trim();

--- a/src/telegramFiles.ts
+++ b/src/telegramFiles.ts
@@ -1,0 +1,39 @@
+/**
+ * The Telegram bot token travels INSIDE the URL of every file a customer sends:
+ *
+ *   https://api.telegram.org/file/bot<TOKEN>/photos/file_12.jpg
+ *
+ * That URL used to be stored verbatim in the `[IMAGE_URL: …]` marker of the
+ * message, which means the bot token ends up in D1 — and in the dashboard
+ * thread, and in every conversation export.
+ *
+ * With that token anyone can read every message the bot receives, reply as the
+ * bot, and repoint its webhook. No access to Cloudflare or to the dashboard
+ * needed: the text of a stored message is enough. For anyone reselling bots,
+ * the token that leaks is not theirs — it belongs to the business they set it
+ * up for.
+ *
+ * Rule: the token is MASKED on the way in and put back only at the moment the
+ * file is actually fetched.
+ */
+
+/** Placeholder that replaces the token in anything we persist. */
+export const TELEGRAM_TOKEN_MASK = "bot__TOKEN__";
+
+/** `https://api.telegram.org/file/bot<TOKEN>/x.jpg` → `…/bot__TOKEN__/x.jpg` */
+const RE_FILE_URL = /^(https:\/\/api\.telegram\.org\/file\/)bot[^/]+(\/.*)$/;
+
+/** Takes the token out of a Telegram file URL, so it can be stored safely. */
+export function maskTelegramToken(url: string): string {
+  return url.replace(RE_FILE_URL, `$1${TELEGRAM_TOKEN_MASK}$2`);
+}
+
+/**
+ * Puts the token back, right before fetching the file. A URL that was never
+ * masked (or that is not from Telegram) comes back untouched, so this is safe
+ * to call on any image URL.
+ */
+export function unmaskTelegramToken(url: string, token: string | undefined): string {
+  if (!token || !url.includes(TELEGRAM_TOKEN_MASK)) return url;
+  return url.replace(TELEGRAM_TOKEN_MASK, `bot${token}`);
+}

--- a/test/telegramFiles.test.ts
+++ b/test/telegramFiles.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import {
+  maskTelegramToken,
+  unmaskTelegramToken,
+  TELEGRAM_TOKEN_MASK,
+} from "../src/telegramFiles";
+
+// A token shaped like a real one, but obviously fake.
+const TOKEN = "8123456789:AAHfakefakefakefakefakefakefake";
+const REAL = `https://api.telegram.org/file/bot${TOKEN}/photos/file_12.jpg`;
+
+describe("telegram file URLs — the bot token must not be stored", () => {
+  it("takes the token out of the URL", () => {
+    const masked = maskTelegramToken(REAL);
+    expect(masked).not.toContain(TOKEN);
+    expect(masked).toBe(
+      `https://api.telegram.org/file/${TELEGRAM_TOKEN_MASK}/photos/file_12.jpg`,
+    );
+  });
+
+  it("puts it back, byte for byte, to fetch the file", () => {
+    expect(unmaskTelegramToken(maskTelegramToken(REAL), TOKEN)).toBe(REAL);
+  });
+
+  it("leaves other image URLs alone", () => {
+    const otra = "https://example.com/una-foto.png";
+    expect(maskTelegramToken(otra)).toBe(otra);
+    expect(unmaskTelegramToken(otra, TOKEN)).toBe(otra);
+  });
+
+  it("does not blow up when there is no token configured", () => {
+    const masked = maskTelegramToken(REAL);
+    expect(unmaskTelegramToken(masked, undefined)).toBe(masked);
+  });
+
+  it("keeps the file path intact, including nested folders", () => {
+    const anidada = `https://api.telegram.org/file/bot${TOKEN}/voice/a/b/c.ogg`;
+    expect(unmaskTelegramToken(maskTelegramToken(anidada), TOKEN)).toBe(anidada);
+  });
+});


### PR DESCRIPTION
## El problema

La URL de cualquier archivo que un cliente manda por Telegram **lleva el token del bot adentro**. Es cómo funciona la Bot API, y `telegram.ts` la devuelve tal cual:

```ts
return `https://api.telegram.org/file/bot${token}/${json.result.file_path}`;
```

Esa URL termina guardada literal en el marcador `[IMAGE_URL: …]` del mensaje (`agent.ts`), o sea **dentro de D1**. Y de ahí sale por varios lados: se ve en el hilo del panel y viaja dentro de las exportaciones de conversaciones.

Con ese token se puede leer todo lo que le llega al bot, contestar en su nombre y cambiar a dónde apunta el webhook. No hace falta acceso a Cloudflare ni al panel: alcanza con el texto de un mensaje guardado.

Para quien revende bots, el token que se filtra **no es el suyo**: es el del negocio al que se lo instaló.

Le pasa a cualquier instalación con Telegram conectado en la que un cliente haya mandado una foto.

## Qué hace este PR

Regla: **el token se enmascara al guardar y se repone solo en el instante de descargar el archivo.**

- Módulo nuevo `src/telegramFiles.ts` con `maskTelegramToken()` / `unmaskTelegramToken()`.
- `agent.ts` enmascara antes de escribir el marcador `[IMAGE_URL: …]`, que es lo que se persiste.
- `agent.ts` lo repone justo antes de armar el mensaje multimodal, que es el único momento en que se necesita de verdad.

Una URL que no sea de Telegram pasa intacta, así que es seguro llamarlo sobre cualquier imagen.

**Lo que este PR NO hace:** limpiar las filas que ya están guardadas con el token. Eso es una migración y va aparte. Quien tenga Telegram conectado hace tiempo conviene que además **genere un token nuevo con BotFather**, porque el viejo pudo haber salido ya en alguna exportación.

## Pruebas

5 casos nuevos en `test/telegramFiles.test.ts`: que el token sale de la URL, que vuelve byte por byte, que las URLs de otros orígenes no se tocan, que no truena sin token configurado, y que las rutas con carpetas anidadas sobreviven.

**442 pruebas pasan** (eran 437) y `tsc --noEmit` limpio.

## Contexto

Somos [Escuela Con Confianza](https://escuelaconconfianza.com), una escuela de terapia para la tartamudez en Lima. Corremos Forja en producción desde julio, y esto apareció revisando por qué el panel no mostraba las imágenes que mandaban los clientes.

Ya está corriendo en nuestro bot desde el 28/07. Auditamos nuestra base después de aplicarlo: de 800 mensajes, el único con una URL de Telegram quedó enmascarado y ninguno tiene el token en claro.

Es el tercero de tres. Los otros son #6 (la alarma perdida del buffer) y #7 (el mensaje del cliente que se pierde al pausar el bot).

@santmun si prefieres que esto se hubiera manejado en privado antes de publicarlo, dime y lo tengo en cuenta para la próxima. Lo subimos así porque viene con el arreglo listo, no solo con el reporte.
