### PR TITLE
Panel: mostrar fechas y horas en la zona horaria del negocio (no en UTC)

### DIFF
--- a/src/admin/format.ts
+++ b/src/admin/format.ts
@@ -1,0 +1,24 @@
+import { memberConfig } from "../../member/config.local";
+
+// El Worker corre con reloj de sistema en UTC, así que `toLocaleString` /
+// `toLocaleDateString` SIN `timeZone` explícito renderizan cada fecha del panel
+// en UTC — un miembro en America/Costa_Rica vería las horas 6h adelantadas.
+// Este helper ancla TODAS las fechas del panel a la zona horaria del negocio,
+// declarada en member/config.local.ts (el dato ya existía; el panel no lo usaba).
+const BUSINESS_TZ = memberConfig.timezone || "America/Mexico_City";
+
+/** Fecha + hora en la zona del negocio (reemplaza `new Date(x).toLocaleString("es-MX")`). */
+export function fmtDateTime(
+  ts: number | string | Date,
+  opts: Intl.DateTimeFormatOptions = {},
+): string {
+  return new Date(ts).toLocaleString("es-MX", { timeZone: BUSINESS_TZ, ...opts });
+}
+
+/** Solo fecha en la zona del negocio (reemplaza `new Date(x).toLocaleDateString("es-MX")`). */
+export function fmtDate(
+  ts: number | string | Date,
+  opts: Intl.DateTimeFormatOptions = {},
+): string {
+  return new Date(ts).toLocaleDateString("es-MX", { timeZone: BUSINESS_TZ, ...opts });
+}

--- a/src/admin/views/conversations.ts
+++ b/src/admin/views/conversations.ts
@@ -18,6 +18,7 @@ import { SENTIMENT_BADGE } from "./insights";
 import { costOfUsage, type ModelId } from "../../pricing";
 import { channelLabel } from "../../channels/labels";
 import { layout } from "./layout";
+import { fmtDateTime } from "../format";
 
 /** Tiempo relativo corto en español (ej. "hace 5 min", "hace 2 h", "hace 3 d"). */
 function ago(ms: number | null | undefined): string {
@@ -270,7 +271,7 @@ export async function renderThreadLive(env: Env, convId: string): Promise<string
   // Messages, DESC in the DOM + column-reverse = pinned to bottom.
   const bubbles = msgs
     .map((m) => {
-      const time = new Date(m.created_at).toLocaleString("es-MX", {
+      const time = fmtDateTime(m.created_at, {
         day: "2-digit", month: "short", hour: "2-digit", minute: "2-digit",
       });
 

--- a/src/admin/views/leads.ts
+++ b/src/admin/views/leads.ts
@@ -3,6 +3,7 @@ import { Db } from "../../db/client";
 import { LeadsRepo, leadMetadata, type Lead } from "../../db/leads";
 import { getNiche } from "../../niches";
 import { layout } from "./layout";
+import { fmtDate, fmtDateTime } from "../format";
 
 // Escapa texto del LLM/cliente antes de meterlo en HTML (el intent y las notas
 // pueden traer <, &, links pegados por el cliente, etc.).
@@ -26,7 +27,7 @@ export async function renderLeads(env: Env): Promise<string> {
   // Columnas: núcleo (fecha, nombre, contacto) + o bien las columnas del nicho
   // (leídas de metadata) o bien el "Resumen" genérico + estado (re-etiquetado).
   const cols: Col[] = [
-    { h: "Fecha", w: "94px", cell: (l) => `<span class="text-dim">${new Date(l.created_at).toLocaleDateString("es-MX")}</span>` },
+    { h: "Fecha", w: "94px", cell: (l) => `<span class="text-dim">${fmtDate(l.created_at)}</span>` },
     { h: "Nombre", w: "minmax(120px,1.1fr)", cell: (l) => `<span class="text-cream" style="display:flex;align-items:center;gap:7px"><i data-lucide="chevron-right" width="13" height="13" class="chev" style="flex:none;transition:transform .12s ease"></i>${esc(l.name) || "(sin nombre)"}</span>` },
     { h: "Contacto", w: "minmax(110px,1fr)", cell: (l) => `<span class="text-muted">${esc(l.contact) || "—"}</span>` },
   ];
@@ -56,7 +57,7 @@ export async function renderLeads(env: Env): Promise<string> {
   const rows = list
     .map((l) => {
       const meta = leadMetadata(l);
-      const fullDate = new Date(l.created_at).toLocaleString("es-MX");
+      const fullDate = fmtDateTime(l.created_at);
       const convLink = l.conversation_id
         ? `<a href="/admin/conversations?c=${encodeURIComponent(l.conversation_id)}" class="text-accent" style="display:inline-flex;align-items:center;gap:6px;font-size:12px;text-decoration:none">
              <i data-lucide="messages-square" width="13" height="13"></i> Ver conversación completa

--- a/src/admin/views/tickets.ts
+++ b/src/admin/views/tickets.ts
@@ -2,6 +2,7 @@ import type { Env } from "../../env";
 import { Db } from "../../db/client";
 import { TicketsRepo } from "../../db/tickets";
 import { layout } from "./layout";
+import { fmtDateTime } from "../format";
 
 const STATUS_PILL: Record<string, string> = {
   open: "var(--bad)",
@@ -14,7 +15,7 @@ export async function renderTickets(env: Env): Promise<string> {
 
   const list = open
     .map((t) => {
-      const date = new Date(t.created_at).toLocaleString("es-MX");
+      const date = fmtDateTime(t.created_at);
       const pillColor = STATUS_PILL[t.status] ?? "var(--muted)";
       return `<div class="tkcard bg-panel border border-line" style="padding:16px 18px;margin-bottom:12px">
         <div style="display:flex;align-items:center;justify-content:space-between;gap:10px;margin-bottom:8px">


### PR DESCRIPTION
## Qué esperaba que pasara
Que las fechas y horas del panel (Conversaciones, Leads, Tickets) se muestren en la zona horaria del negocio, declarada en `member/config.local.ts` como `timezone`.

## Qué pasaba
Todas las horas del panel salían en UTC. Un mensaje recibido a las 12:36 (America/Costa_Rica) aparecía como 18:36 — un desfase igual al offset de la zona. Afecta a cualquier miembro que no esté en UTC.

## Causa
Las llamadas de formato usaban `toLocaleString("es-MX")` / `toLocaleDateString("es-MX")` **sin** la opción `timeZone`. El panel se renderiza dentro del Worker, cuyo reloj de sistema es UTC, así que "local" significaba UTC.

## Arreglo
Helper central nuevo `src/admin/format.ts` (`fmtDateTime` / `fmtDate`) que inyecta `{ timeZone: memberConfig.timezone }`. El dato ya existía en `member/config.local.ts`; el panel simplemente no lo usaba.

Sitios corregidos:
- `src/admin/views/conversations.ts` — hora de cada mensaje
- `src/admin/views/leads.ts` — columna "Fecha" y fecha completa del lead
- `src/admin/views/tickets.ts` — fecha del ticket

## Cómo se prueba
1. Configura un `timezone` distinto de UTC en `member/config.local.ts` (ej. `"America/Costa_Rica"`).
2. Recibe un mensaje / genera un lead o ticket.
3. Abre `/admin/conversations` (o `/leads`, `/tickets`) y compara con la hora local real: coinciden.

Verificado: `pnpm typecheck` limpio y los 84 tests de `test/admin/` pasan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized date and time display across the admin panel.
  * Dates and timestamps now consistently use Spanish (Mexico) formatting and the configured business timezone.
  * Updated conversations, leads, and tickets views for consistent timestamp presentation.
  * Supports customized date and time display options where needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->