### PR TITLE
Inbox: no perder el scroll al refrescar (el polling impide leer el historial)

### DIFF
--- a/src/admin/views/conversations.ts
+++ b/src/admin/views/conversations.ts
@@ -316,7 +316,7 @@ export async function renderThreadLive(env: Env, convId: string): Promise<string
 
   return `
   ${header}
-  <div style="flex:1;min-height:0;overflow-y:auto;display:flex;flex-direction:column-reverse;gap:12px;padding:16px;background:var(--bg)">
+  <div id="msgscroll" style="flex:1;min-height:0;overflow-y:auto;display:flex;flex-direction:column-reverse;gap:12px;padding:16px;background:var(--bg)">
     ${bubbles || `<div style="text-align:center;font-size:12.5px;color:var(--dim);padding:32px 0">Sin mensajes.</div>`}
   </div>`;
 }
@@ -403,7 +403,7 @@ export async function renderInbox(env: Env, p: InboxParams): Promise<string> {
     rightPane = `
       <div id="thread-live" class="flex flex-col flex-1 min-h-0"
            hx-get="/admin/conversations/thread/${encodeURIComponent(p.selectedId)}"
-           hx-trigger="every 5s" hx-swap="innerHTML">
+           hx-trigger="every 5s[window.puedeRefrescar('msgscroll')]" hx-swap="innerHTML">
         ${thread}
       </div>
       ${renderComposer(p.selectedId)}`;
@@ -433,7 +433,7 @@ export async function renderInbox(env: Env, p: InboxParams): Promise<string> {
     <div class="grid grid-cols-1 md:grid-cols-[320px_1fr] overflow-hidden" style="border:1px solid var(--line);background:var(--panel);height:calc(100vh - 200px);min-height:480px">
       <div class="border-r border-line flex flex-col" style="min-height:0">
         <div id="conv-list" class="overflow-y-auto flex-1"
-             hx-get="${listPollUrl}" hx-trigger="every 10s" hx-swap="innerHTML">
+             hx-get="${listPollUrl}" hx-trigger="every 10s[window.puedeRefrescar('conv-list')]" hx-swap="innerHTML">
           ${list}
         </div>
       </div>

--- a/src/admin/views/layout.ts
+++ b/src/admin/views/layout.ts
@@ -222,6 +222,19 @@ const GLOBAL_SCRIPT = `
   (function(){ var n=0; var t=setInterval(function(){ if(window.lucide){drawIcons();clearInterval(t);} if(++n>25) clearInterval(t); },120); })();
   document.body.addEventListener("htmx:afterSwap", drawIcons);
   document.body.addEventListener("htmx:oobAfterSwap", drawIcons);
+  // Pausa del polling: no refresques el inbox mientras el usuario lee (o si la
+  // pestaña está en segundo plano). htmx evalúa este filtro en cada tick de
+  // 'every Ns[...]' y solo dispara la petición si devuelve true. En el hilo
+  // (contenedor flex column-reverse) "al día" = scroll pegado al final, donde
+  // scrollTop ≈ 0; leer historial lo aleja (positivo en Chrome, negativo en
+  // Firefox), de ahí el Math.abs. Al volver al final, el siguiente tick se pone
+  // al día solo.
+  window.puedeRefrescar = function(id){
+    if (document.hidden) return false;
+    var el = document.getElementById(id);
+    if (!el) return true;
+    return Math.abs(el.scrollTop) < 40;
+  };
   document.addEventListener("keydown", function(e){
     if (e.key === "Escape") {
       var root = document.getElementById("modal-root");


### PR DESCRIPTION
## Qué esperaba que pasara
Poder leer una conversación larga en `/admin/conversations` desplazándome hacia arriba, sin que la vista se mueva sola.

## Qué pasaba
Cada 5 s el hilo se recargaba y la vista saltaba de vuelta al final; imposible leer el historial. Lo mismo con la lista de conversaciones cada 10 s.

## Causa
Los contenedores hacían polling con `hx-swap="innerHTML"`, que destruye y reconstruye todos los nodos hijos — el navegador pierde la posición de scroll. Como el hilo usa `flex-direction: column-reverse`, "perder el scroll" significa saltar al final.

```
<div id="thread-live" hx-get="..." hx-trigger="every 5s"  hx-swap="innerHTML">
<div id="conv-list"   hx-get="..." hx-trigger="every 10s" hx-swap="innerHTML">
```

## Arreglo
Se condiciona el `hx-trigger` con un predicado global `window.puedeRefrescar(id)` (en `layout.ts`): htmx evalúa el filtro en cada tick y **solo dispara la petición si devuelve `true`**. Devuelve `false` cuando la pestaña está en segundo plano o cuando el usuario está leyendo historial (scroll lejos del final). Al volver al final, el siguiente tick se pone al día solo.

- `layout.ts` — nuevo helper `window.puedeRefrescar(id)`.
- `conversations.ts` — `id="msgscroll"` en el contenedor de scroll del hilo; `hx-trigger="every 5s[window.puedeRefrescar('msgscroll')]"` en `#thread-live` y `every 10s[window.puedeRefrescar('conv-list')]` en `#conv-list`.

Detalle del `column-reverse`: "al día" = scroll pegado al final, donde `scrollTop ≈ 0`; leer historial lo aleja (positivo en Chrome, negativo en Firefox), de ahí el `Math.abs(scrollTop) < 40`.

## Cómo se prueba
1. Abre `/admin/conversations` y selecciona una conversación con muchos mensajes.
2. Desplázate hacia arriba para leer los viejos.
3. Espera >5 s sin tocar nada: la vista **ya no salta**.
4. Vuelve al final: el siguiente tick retoma el refresco normal.

Verificado: `pnpm typecheck` limpio y los 84 tests de `test/admin/` pasan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
