### PR TITLE
Respuestas en texto plano — ningún canal renderiza Markdown

### DIFF
--- a/src/replies/chunker.ts
+++ b/src/replies/chunker.ts
@@ -1,8 +1,23 @@
 const DEFAULT_MAX_CHUNKS = 3;
 
+/**
+ * Limpia el Markdown de la respuesta antes de enviarla. Ningún canal del bot lo
+ * renderiza: el widget web pinta con textContent (los símbolos llegan crudos) y
+ * WhatsApp usa *un* asterisco para negrita, no dos — así que **texto** se ve
+ * roto en todos lados. El <style_guide> ya pide texto plano, pero el modelo a
+ * veces pone negritas igual; esto es la red de seguridad.
+ */
+export function stripMarkdown(text: string): string {
+  return text
+    .replace(/(\*\*|__)([^\n]+?)\1/g, "$2") // **negrita** / __negrita__ → negrita
+    .replace(/`([^`\n]+)`/g, "$1") //          `código` → código
+    .replace(/^\s{0,3}#{1,6}\s+/gm, "") //     # Encabezado → sin marcador
+    .replace(/^[ \t]*[-*]\s+/gm, "• "); //     viñeta "- " / "* " → "• "
+}
+
 export function chunkReply(text: string, maxChunks: number = DEFAULT_MAX_CHUNKS): string[] {
   const cap = Math.max(1, Math.floor(maxChunks));
-  const trimmed = text.trim();
+  const trimmed = stripMarkdown(text).trim();
 
   if (cap === 1) return [trimmed];
 

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -81,7 +81,9 @@ NO escales cuando:
 </escalation_rules>
 
 <style_guide>
-- Markdown OK para pasos numerados / código inline.
+- Texto plano SIEMPRE. Ningún canal renderiza Markdown: nada de **negritas**,
+  *cursivas*, acentos graves para código, ni viñetas con "-" o "*". Para listas
+  usa números (1. 2. 3.) o el símbolo "•". Los símbolos crudos le llegan al cliente.
 - NO uses headers (#) — esto es chat, no documento.
 - NO uses tablas — bubbles son angostas.
 - Emojis: cero, excepto ✓ al confirmar acción exitosa.

--- a/test/replies/chunker.test.ts
+++ b/test/replies/chunker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { chunkReply } from "../../src/replies/chunker";
+import { chunkReply, stripMarkdown } from "../../src/replies/chunker";
 
 describe("chunkReply", () => {
   it("returns single chunk for short text", () => {
@@ -34,5 +34,23 @@ describe("chunkReply", () => {
     const joined = chunks.join(" ").replace(/\s+/g, " ");
     const original = text.replace(/\s+/g, " ");
     expect(joined).toBe(original);
+  });
+
+  it("strips Markdown before sending (no channel renders it)", () => {
+    expect(stripMarkdown("**PAQUETE BASE**")).toBe("PAQUETE BASE");
+    expect(stripMarkdown("hola __mundo__")).toBe("hola mundo");
+    expect(stripMarkdown("usa `codigo` aquí")).toBe("usa codigo aquí");
+    expect(stripMarkdown("# Título")).toBe("Título");
+    expect(stripMarkdown("- uno\n- dos")).toBe("• uno\n• dos");
+    expect(stripMarkdown("* item")).toBe("• item");
+  });
+
+  it("leaves plain text and numbered lists untouched", () => {
+    expect(stripMarkdown("Precio: $250 (2 x $125)")).toBe("Precio: $250 (2 x $125)");
+    expect(stripMarkdown("1. Primero\n2. Segundo")).toBe("1. Primero\n2. Segundo");
+  });
+
+  it("chunkReply sanitizes Markdown in its output", () => {
+    expect(chunkReply("**Hola** María")).toEqual(["Hola María"]);
   });
 });


### PR DESCRIPTION
## Qué esperaba que pasara
Que las respuestas del bot lleguen al cliente como texto legible en todos los canales.

## Qué pasaba
El bot respondía con Markdown y al cliente le llegaban los símbolos crudos: en el chat del sitio web se veían asteriscos literales alrededor de los títulos (`**PAQUETE BASE**`), y en WhatsApp también se rompe (ahí la negrita lleva **un** asterisco, no dos).

## Causa
El `<style_guide>` del prompt decía literalmente *"Markdown OK para pasos numerados / código inline"*, pero ningún canal lo interpreta: el widget web asigna el texto con `textContent` (cualquier símbolo llega visible) y WhatsApp usa un solo asterisco. Además, aun corrigiendo el prompt, el modelo seguía poniendo negritas en los títulos: la instrucción sola no alcanza.

## Arreglo
1. **`system-prompt.ts`** — el `<style_guide>` ahora exige **texto plano siempre** (nada de negritas, cursivas, código con acentos graves, ni viñetas con `-`/`*`; para listas, números `1. 2. 3.` o el símbolo `•`).
2. **`chunker.ts`** — `stripMarkdown()` como red de seguridad, aplicado en `chunkReply` (el único embudo de la respuesta del LLM): limpia `**negrita**`/`__negrita__`, código en línea, encabezados `#` y viñetas `-`/`*` → `•`, dejando intactos números, precios (`$250`) y texto normal.
3. **`chunker.test.ts`** — 3 tests nuevos.

## Cómo se prueba
1. Pídele al bot algo que invite a una lista (detalle de precios / un paquete).
2. La respuesta ya no trae `**` alrededor de los títulos ni viñetas de guion crudas.

Verificado: `pnpm typecheck` limpio; 18/18 en `test/replies/` (incluye los nuevos) y 17/17 en `system-prompt` + `agent.media`.

> Nota: el widget web (`src/web/script.ts`) no está en este repo (es de la capa Pro), pero el arreglo real —prompt + saneo de salida— es cross-canal y cubre todos los canales, no solo el web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Responses are now presented as cleaner plain text by removing unsupported Markdown formatting.
  * Markdown bullet lists are converted into readable `•` bullets.
  * Numbered lists and existing plain text remain preserved.
* **Bug Fixes**
  * Improved response chunking to sanitize Markdown before displaying content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->