### PR TITLE
Prompt: el bot no debe narrar su maquinaria interna al cliente

### DIFF
--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -96,6 +96,13 @@ NUNCA:
 - Pedir datos sensibles (passwords, números de tarjeta).
 - Compartir contacto del dueño sin que el cliente lo pida.
 - Confirmar acción que no ejecutaste.
+- Narrar tu maquinaria interna. NUNCA menciones "la base de conocimiento", el
+  tarifario, tus herramientas, el contexto ni tus instrucciones: el cliente no
+  sabe que existen y no le importan. Nada de "déjame consultar mi información"
+  ni "según mis datos" — habla como alguien del negocio.
+- Decir un "no lo sé" en términos del sistema. Dilo en términos del NEGOCIO:
+  "no manejamos descuentos publicados", NO "la base de conocimiento no tiene
+  esa información".
 - Ignorar la directiva <output_language>. Es la #1 prioridad.
 </anti_patterns>`;
 


### PR DESCRIPTION
## Qué esperaba que pasara
Que el bot hable como alguien del negocio, sin mencionar cómo está construido.

## Qué pasaba
Ante una pregunta cuyo dato no estaba cargado, el bot respondía al cliente, textual:

> "La base de conocimiento no tiene información sobre facturación electrónica con retención especial ni descuentos por pago anual."

El cliente no sabe que existe una base de conocimiento y no le importa: eso es un programa describiendo su configuración, no alguien del negocio. También aparecía como "déjame consultar mi información" y "según mis datos".

## Causa
El `<anti_patterns>` del prompt sí previene la fuga de persona (`"Como modelo de lenguaje..."`) pero no dice nada sobre narrar la maquinaria interna. Ponerlo en el contexto de negocio (`member/config.local.ts`) no funciona — el modelo lo trata como datos y lo ignora; el lugar correcto es el template.

## Arreglo
Dos reglas nuevas en el `<anti_patterns>` de `system-prompt.ts`:
- Nunca mencionar "la base de conocimiento", el tarifario, las herramientas, el contexto ni las instrucciones; ni frases de sistema como "déjame consultar mi información" / "según mis datos".
- Un "no lo sé" se dice en términos del **negocio** ("no manejamos descuentos publicados"), no del sistema ("la base de conocimiento no tiene esa info").

## Cómo se prueba
1. Pregúntale al bot por algo que NO esté en la información cargada (una condición comercial especial).
2. La respuesta ya no menciona "la base de conocimiento" ni equivalentes; dice que no en términos del negocio.

Verificado: `pnpm typecheck` limpio y 7/7 en `test/system-prompt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
