### PR TITLE
fix(deps): fijar las seis dependencias declaradas como "latest"

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "latest",
-    "@types/node": "latest",
-    "miniflare": "latest",
-    "tsx": "latest",
+    "@cloudflare/workers-types": "^4.20260531.1",
+    "@types/node": "^25.9.1",
+    "miniflare": "^4.20260526.0",
+    "tsx": "^4.22.3",
     "typescript": "^5",
-    "vitest": "latest",
-    "wrangler": "latest"
+    "vitest": "^4.1.7",
+    "wrangler": "^4.95.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,25 +37,25 @@ importers:
         version: 4.4.3
     devDependencies:
       '@cloudflare/workers-types':
-        specifier: latest
+        specifier: ^4.20260531.1
         version: 4.20260531.1
       '@types/node':
-        specifier: latest
+        specifier: ^25.9.1
         version: 25.9.1
       miniflare:
-        specifier: latest
+        specifier: ^4.20260526.0
         version: 4.20260526.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       tsx:
-        specifier: latest
+        specifier: ^4.22.3
         version: 4.22.3
       typescript:
         specifier: ^5
         version: 5.9.3
       vitest:
-        specifier: latest
+        specifier: ^4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.3))
       wrangler:
-        specifier: latest
+        specifier: ^4.95.0
         version: 4.95.0(@cloudflare/workers-types@4.20260531.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
 packages:


### PR DESCRIPTION
## Qué problema resuelve

Seis `devDependencies` están declaradas como `"latest"`:

```
"@cloudflare/workers-types": "latest",
"@types/node": "latest",
"miniflare": "latest",
"tsx": "latest",
"vitest": "latest",
"wrangler": "latest"
```

Con el lockfile presente la instalación es reproducible, así que en el día a día
no se nota. El problema aparece en cuanto el lock no manda:

- un `pnpm install` sin lockfile,
- un `pnpm update`,
- un bot recién armado por el CLI.

En esos casos la instalación toma lo que haya salido ese día. Si esa versión
cruzó un major, el bot se rompe sin que nadie haya tocado una línea de código —
y el que lo sufre es el que está instalando, no el que hizo el cambio.

**Ya pasó.** `vitest` saltó a 4.x y la suite dejó de correr: v4 quitó
`poolOptions`. El repo estaba igual que el día anterior.

Es la clase de falla más cara de diagnosticar, porque el primer instinto es
buscar el error en el código propio.

## Qué hace este PR

Fija los seis rangos a **exactamente lo que el lockfile ya resuelve hoy**:

| Paquete | Antes | Ahora |
|---|---|---|
| `@cloudflare/workers-types` | `latest` | `^4.20260531.1` |
| `@types/node` | `latest` | `^25.9.1` |
| `miniflare` | `latest` | `^4.20260526.0` |
| `tsx` | `latest` | `^4.22.3` |
| `vitest` | `latest` | `^4.1.7` |
| `wrangler` | `latest` | `^4.95.0` |

Caret, no versión exacta: los parches y minors siguen entrando solos, que es lo
que se quiere. Lo único que se cierra es el salto de major.

**No mueve ninguna versión instalada.** Los rangos incluyen lo que ya está
resuelto, así que `pnpm install` produce el mismo árbol que antes de este PR.

## Sobre el lockfile

Cambian 6 líneas, todas `specifier:`. El grafo resuelto queda idéntico —
ninguna línea `version:` se toca.

Vale aclarar por qué está editado a mano y no regenerado: correr
`pnpm install --lockfile-only` en este repo arrastra cambios que no tienen nada
que ver con este PR (`@solana/sysvars` se re-resuelve de 5.5.1 a 2.3.0, entran
entradas de `debug` y `supports-color`). Eso es ruido de peers que se
re-evalúan, y meterlo aquí escondería el cambio real detrás de 250 líneas de
diff. Si preferís el lock regenerado, decime y lo mando así.

## Lo que dejé como estaba

`typescript: "^5"` no lo toqué. Es laxo pero no es `latest`, y subir de major
ahí sí puede pedir cambios de código — merece su propia decisión, no ir de
colado en este PR.

## Verificación

- `pnpm install --frozen-lockfile` pasa. Era lo que había que probar: si el
  `specifier` del lock no cuadrara con `package.json`, CI fallaría con
  `ERR_PNPM_OUTDATED_LOCKFILE`.
- El lockfile no se mueve después de correrlo.
- `pnpm typecheck` limpio.
