### PR TITLE
fix(test): excluir los archivos AppleDouble de macOS de la suite

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, configDefaults } from "vitest/config";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -20,6 +20,19 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["test/**/*.test.ts"],
+    // macOS mete un archivo AppleDouble (`._algo`) al lado de cada archivo real
+    // cuando empaqueta un tar/zip con atributos extendidos. Los que quedan como
+    // `._loquesea.test.ts` casan con el `include` de arriba, y Vitest intenta
+    // cargarlos como módulos: no son JavaScript, así que se lleva por delante el
+    // worker con un "Worker exited unexpectedly" que no dice qué archivo fue.
+    //
+    // Nada los genera dentro del repo — llegan en el tarball de distribución.
+    // Esto es la red de seguridad del lado del consumidor: aunque el paquete
+    // venga sucio, la suite corre.
+    //
+    // `exclude` reemplaza el valor por defecto en vez de sumarse, así que hay que
+    // reponerlo con configDefaults o se pierde el filtro de node_modules.
+    exclude: [...configDefaults.exclude, "**/._*"],
     pool: "forks",
     poolOptions: { forks: { singleFork: true } },
     // Most tests spin up a real Miniflare (workerd process + full D1 schema)


### PR DESCRIPTION
## Qué problema resuelve

Al instalar un bot nuevo, `pnpm test` reportaba decenas de archivos fallidos con
`Worker exited unexpectedly`, de forma intermitente y sin señalar cuál archivo.
Ninguna prueba real fallaba.

La causa: el tarball trae **415 archivos AppleDouble** — los `._algo` que macOS
mete al lado de cada archivo real cuando empaqueta un tar o zip con atributos
extendidos. 124 caen en `test/`, y los que quedan como `._loquesea.test.ts`
casan con el `include` de Vitest:

```ts
include: ["test/**/*.test.ts"],
```

Vitest intenta cargarlos como módulos de JavaScript. No lo son —son un formato
binario de metadatos— así que el worker muere.

La cuenta cuadraba exacta: 94 archivos de prueba reales + 94 `._*.test.ts` = los
188 que reportaba.

Lo peor no es que falle, es **cómo** falla: el error no nombra el archivo
culpable, cambia entre corridas, y quien instala concluye que su entorno está
roto.

## Qué hace este PR

Agrega `**/._*` al `exclude` de Vitest.

```ts
exclude: [...configDefaults.exclude, "**/._*"],
```

El `configDefaults` no es decorativo: `exclude` **reemplaza** el valor por
defecto en vez de sumarse, así que sin él se pierde el filtro de
`node_modules`.

## Esto es la red, no la raíz

Nada dentro del repo genera estos archivos — verificado, no hay ninguno
versionado. Llegan en el tarball de distribución, empaquetado desde un Mac.

**La raíz se arregla al empaquetar**, con `COPYFILE_DISABLE=1` o `--no-xattrs`.
Eso vive en el CLI, no acá, así que no lo puedo mandar en este PR. Ideal sería
hacer las dos cosas: que el paquete salga limpio, y que la suite aguante si algún
día no sale.

## Verificación

Reproducido con **un solo** señuelo, un AppleDouble real de 32 bytes puesto en
`test/db/`:

**Sin el exclude** — la corrida ni llega a reportar, la salida se llena de
binario:

```
Failed Suites 1
Error: Transform failed with 1 error:
Error: [vitest-pool]: Worker forks emitted error.
Caused by: Error: Worker exited unexpectedly
Test Files  1 failed | 8 passed (10)
Errors  1 error
```

**Con el exclude:**

```
Test Files  9 passed (9)
     Tests  28 passed (28)
```

Un señuelo bastó para tumbar la corrida. En el tarball venían 94.
