### PR TITLE
docs(kb): documentar el orden real del reindexado y avisar si falta el secret

### DIFF
--- a/scripts/generate-fixtures.ts
+++ b/scripts/generate-fixtures.ts
@@ -145,7 +145,12 @@ function main(): void {
   }
   console.log(
     "ℹ️  Manifest regenerated. Trigger the real Vectorize reindex AFTER deploy:\n" +
-      '    curl -X POST https://<worker>/kb/reindex -H "X-Reindex-Token: $KB_REINDEX_TOKEN"',
+      "    1. pnpm deploy\n" +
+      "    2. wrangler secret put KB_REINDEX_TOKEN     (después del deploy)\n" +
+      '    3. curl -X POST https://<worker>/kb/reindex -H "X-Reindex-Token: $KB_REINDEX_TOKEN"\n' +
+      "\n" +
+      "    Si el paso 3 devuelve {\"ok\":false,\"error\":\"unauthorized\"}, esperá unos\n" +
+      "    segundos y reintentá: el secret tarda en propagarse. No es tu token.",
   );
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,12 +202,33 @@ app.route("/admin", adminApp);
 app.route("/api", apiApp);
 
 // KB reindex — embeds scripts/kb-fixtures.json into Vectorize. Guarded by the
-// KB_REINDEX_TOKEN secret via the X-Reindex-Token header. Trigger after deploy:
-//   curl -X POST https://<worker>/kb/reindex -H "X-Reindex-Token: <token>"
+// KB_REINDEX_TOKEN secret via the X-Reindex-Token header.
+//
+// El orden importa, y no es el intuitivo:
+//   1. pnpm kb:reindex        (regenera el manifiesto)
+//   2. pnpm deploy
+//   3. wrangler secret put KB_REINDEX_TOKEN     <- DESPUÉS del deploy
+//   4. curl -X POST https://<worker>/kb/reindex -H "X-Reindex-Token: <token>"
+//
+// El secret va después del deploy porque un deploy posterior lo puede dejar sin
+// efecto. Y aun haciéndolo en este orden, el paso 4 puede devolver
+// `unauthorized` en el primer intento: el secret tarda unos segundos en
+// propagarse por el edge. Esperar y reintentar resuelve — el token no está mal.
 app.post("/kb/reindex", async (c) => {
   const provided = c.req.header("X-Reindex-Token") ?? "";
   const expected = c.env.KB_REINDEX_TOKEN ?? "";
-  if (!expected || !tokensMatch(provided, expected)) {
+  if (!expected) {
+    // Distinto de "token equivocado", pero la respuesta es la misma a propósito:
+    // decirle a quien llama que el Worker no tiene secret es regalarle
+    // información. El aviso va al log, donde lo ve el dueño con `wrangler tail`
+    // y nadie más. Sin esto, un secret que no propagó y un token mal copiado se
+    // ven idénticos desde afuera.
+    console.warn(
+      "kb/reindex: KB_REINDEX_TOKEN no está configurado en este Worker (o todavía no propagó); toda llamada va a devolver unauthorized",
+    );
+    return c.json({ ok: false, error: "unauthorized" }, 401);
+  }
+  if (!tokensMatch(provided, expected)) {
     return c.json({ ok: false, error: "unauthorized" }, 401);
   }
   const r = await reindexKb(c.env);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -29,4 +29,41 @@ describe("Worker entry", () => {
     const res = await worker.fetch(new Request("https://test/nope"), env, {} as any);
     expect(res.status).toBe(404);
   });
+
+  describe("POST /kb/reindex", () => {
+    const pedir = (headers: Record<string, string>, entorno: any = env) =>
+      worker.fetch(
+        new Request("https://test/kb/reindex", { method: "POST", headers }),
+        entorno,
+        {} as any,
+      );
+
+    it("responde unauthorized cuando el secret no está configurado", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const res = await pedir({ "X-Reindex-Token": "loquesea" });
+
+      expect(res.status).toBe(401);
+      expect(await res.json()).toEqual({ ok: false, error: "unauthorized" });
+
+      // El cuerpo no distingue este caso del token equivocado — a propósito, para
+      // no regalarle a quien llama el estado del Worker. Pero el dueño tiene que
+      // poder distinguirlo desde `wrangler tail`, y ahí es donde va el aviso.
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("KB_REINDEX_TOKEN"));
+      warn.mockRestore();
+    });
+
+    it("responde unauthorized cuando el token no coincide, sin avisar al log", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const res = await pedir({ "X-Reindex-Token": "equivocado" }, {
+        ...env,
+        KB_REINDEX_TOKEN: "el-bueno",
+      });
+
+      expect(res.status).toBe(401);
+      expect(await res.json()).toEqual({ ok: false, error: "unauthorized" });
+      // Acá el Worker sí está configurado: no hay nada que avisarle al dueño.
+      expect(warn).not.toHaveBeenCalled();
+      warn.mockRestore();
+    });
+  });
 });


### PR DESCRIPTION
## Qué problema resuelve

Siguiendo el procedimiento de reindexar la KB **tal como está escrito**, la
llamada devuelve:

```json
{"ok":false,"error":"unauthorized"}
```

Volver a poner el **mismo** secret y reintentar funciona a la primera.
Reproducido dos veces, en dos días distintos.

El fondo casi seguro es propagación del secret en el edge de Cloudflare, no
código de Forja — no es algo que este repo pueda arreglar. Pero el
procedimiento documentado falla tal como está escrito, y el que lo sigue
concluye que copió mal su token y se va a buscar el error donde no está.

Hay un segundo problema encima: **el secret hay que ponerlo después del
deploy**, porque un deploy posterior lo puede dejar sin efecto. Eso tampoco
estaba escrito.

## Qué hace este PR

**1 · Documenta el orden real**, en el comentario de la ruta y en lo que
imprime `pnpm kb:reindex`:

```
1. pnpm deploy
2. wrangler secret put KB_REINDEX_TOKEN     (después del deploy)
3. curl -X POST https://<worker>/kb/reindex -H "X-Reindex-Token: $KB_REINDEX_TOKEN"

Si el paso 3 devuelve {"ok":false,"error":"unauthorized"}, esperá unos
segundos y reintentá: el secret tarda en propagarse. No es tu token.
```

**2 · Distingue "no hay secret" de "token equivocado"** — pero solo para el
dueño.

Hoy los dos casos devuelven exactamente lo mismo y no hay manera de saber cuál
es. Ahora, cuando el Worker no tiene el secret configurado, queda un
`console.warn`.

**El cuerpo de la respuesta no cambia.** Sigue siendo `unauthorized` en los dos
casos, a propósito: decirle a quien llama que el Worker no tiene secret es
regalarle información sobre el estado del sistema. El aviso va al log, donde lo
ve el dueño con `wrangler tail` y nadie más.

## Lo que este PR no hace

No arregla la propagación — no se puede desde acá. Tampoco agrega reintento
automático: me pareció que esconder el problema es peor que nombrarlo, y un
reintento silencioso haría más difícil notar un token realmente mal puesto.

Si les parece mejor que `pnpm deploy` dispare el reindexado solo —que es lo que
uno espera después de cambiar la KB— es un cambio más grande y con gusto lo
armo aparte.

## Verificación

Dos pruebas nuevas en `test/index.test.ts`:

- sin secret configurado → 401 `unauthorized` **y** el aviso al log
- con secret y token equivocado → 401 `unauthorized` **sin** aviso (el Worker
  está bien configurado; no hay nada que avisarle al dueño)

La primera **falla contra `main`**, que es lo que la hace útil:

```
AssertionError: expected "warn" to be called with arguments:
  [ StringContaining "KB_REINDEX_TOKEN" ]
Test Files  1 failed (1)
```

Con el cambio: `4 passed (4)`. `pnpm typecheck` limpio, y `test/kb` sigue en
verde.
