### PR TITLE
feat(panel): tema claro opcional con la marca del miembro y letra más grande

### DIFF
--- a/scripts/escala-de-letra.py
+++ b/scripts/escala-de-letra.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+"""
+Saca del código TODOS los tamaños de letra que se usan de verdad, de las tres
+formas en que aparecen, y genera la regla CSS del tema. Nada de adivinar:
+si el tamaño está en el código, entra en la lista.
+
+Formas encontradas:
+  1. style="...font-size:11px..."      (estilo en línea, sin espacio)
+  2. style="...font-size: 11px..."     (con espacio)
+  3. class="text-[10.5px]"             (clase de Tailwind con valor propio)
+"""
+import re
+import pathlib
+from collections import Counter
+
+BASE = pathlib.Path(__file__).resolve().parents[1] / "src" / "admin"
+
+RE_INLINE = re.compile(r"font-size:\s*(\d+(?:\.\d+)?)px")
+RE_TW = re.compile(r"text-\[(\d+(?:\.\d+)?)px\]")
+
+inline, tw, con_espacio = Counter(), Counter(), 0
+for f in BASE.rglob("*.ts"):
+    t = f.read_text(encoding="utf-8")
+    for m in RE_INLINE.finditer(t):
+        inline[float(m.group(1))] += 1
+        if ": " in m.group(0):
+            con_espacio += 1
+    for m in RE_TW.finditer(t):
+        tw[float(m.group(1))] += 1
+
+print(f"tamaños en estilo en línea: {sorted(inline)}")
+print(f"  (de ellos, escritos con espacio: {con_espacio})")
+print(f"tamaños en clases Tailwind : {sorted(tw)}")
+
+# Escala: nada por debajo de 13.5; los chicos suben más que los grandes.
+def escalar(px: float) -> float:
+    if px <= 9.5:
+        return 13.5
+    if px <= 10.5:
+        return 14.0
+    if px <= 11.5:
+        return 14.5
+    if px <= 12.5:
+        return 15.0
+    if px <= 13.5:
+        return 15.5
+    if px <= 14.5:
+        return 16.5
+    if px <= 15:
+        return 17.0
+    return px  # los títulos grandes se quedan como están
+
+
+def fmt(px: float) -> str:
+    return f"{px:g}"
+
+
+lineas = []
+for px in sorted(set(inline) | set(tw)):
+    nuevo = escalar(px)
+    if nuevo == px:
+        continue
+    sel = []
+    if px in inline:
+        sel.append(f'[style*="font-size:{fmt(px)}px"]')
+        sel.append(f'[style*="font-size: {fmt(px)}px"]')
+    if px in tw:
+        # OJO: en CSS hay que escapar los corchetes Y EL PUNTO del decimal.
+        # Sin escapar el punto, ".text-\[10.5px\]" se lee como ".text-\[10"
+        # seguido de ".5px\]" y la regla entera se descarta en silencio: por eso
+        # "USD · deja vacío para quitar el límite" seguía chico (10/08/2026).
+        # En el .ts, cada "\\" del código produce un "\" en el CSS final.
+        sel.append(f'.text-\\\\[{fmt(px).replace(".", "\\\\.")}px\\\\]')
+    lineas.append(f"    {','.join(sel)}{{font-size:{fmt(nuevo)}px !important}}")
+
+salida = "\n".join(lineas)
+destino = pathlib.Path(__file__).resolve().parent / "escala.css"
+destino.write_text(salida, encoding="utf-8")
+print(f"\nreglas generadas: {len(lineas)}")
+print(salida[:600])

--- a/src/admin/views/layout.ts
+++ b/src/admin/views/layout.ts
@@ -12,6 +12,7 @@ import type { Env } from "../../env";
 import { isPro, PRO_ONLY_TABS } from "../../config";
 import { getNiche } from "../../niches";
 import type { NichePack } from "../../niches";
+import { temaClaro } from "./temaClaro";
 
 const UPGRADE_URL = "/admin/upgrade";
 
@@ -317,6 +318,7 @@ export function layout(opts: { title: string; activeTab: string; body: string; e
   <title>${opts.title}</title>
   ${HEAD_ASSETS}
   ${GLOBAL_STYLE}
+  ${temaClaro(opts.env)}
 </head>
 <body class="scanlines">
   <div class="shell">

--- a/src/admin/views/temaClaro.ts
+++ b/src/admin/views/temaClaro.ts
@@ -1,0 +1,140 @@
+/**
+ * TEMA CLARO + ESCALA DE LETRA para el panel de Forja.
+ *
+ * El panel viene en oscuro y con monoespaciada, que se ve muy bien pero cansa
+ * cuando lo tienes abierto ocho horas atendiendo clientes. Esto lo pasa a claro,
+ * con la tipografía y los colores de TU marca, y sube el tamaño de la letra.
+ *
+ * DOS PRINCIPIOS, y son los que lo hacen seguro de aplicar:
+ *
+ *  1. **Es puramente aditivo.** Sin la variable `PANEL_TEMA`, el panel se ve
+ *     EXACTAMENTE como siempre. No se toca ni una vista.
+ *  2. **Solo cambia color y tipografía.** Ni una regla mueve, quita o reordena
+ *     nada de la pantalla. Por eso no puede romper la maquetación.
+ *
+ * CÓMO SE USA
+ *
+ *   wrangler.toml → [vars]
+ *     PANEL_TEMA  = "claro"
+ *     TEMA_FUENTE = "Fira Sans"        # opcional, cualquiera de Google Fonts
+ *     TEMA_COLOR  = "#2f7fbf"          # opcional, el color principal de tu marca
+ *     TEMA_COLOR2 = "#a2670a"          # opcional, el secundario
+ *
+ *   layout.ts (o donde armes el <head>):
+ *     ${opts.env?.PANEL_TEMA === "claro" ? temaClaro(opts.env) : ""}
+ *
+ * LO QUE APRENDÍ HACIÉNDOLO (por si te ahorra las mismas vueltas)
+ *
+ *  · **El fondo no puede ser blanco puro.** Si el fondo y las tarjetas son del
+ *    mismo blanco, la pantalla queda como una hoja plana y deslumbra. Fondo con
+ *    un tono suave de la familia de tu color, tarjetas en blanco encima: se
+ *    separan solas y descansa la vista.
+ *  · **Tu color de marca puede no contrastar sobre blanco.** El ámbar que yo
+ *    usaba se perdía en los enlaces. Por eso el color secundario se puede pasar
+ *    aparte, ya oscurecido, en vez de reusar el de la web tal cual.
+ *  · **Los grises del panel están pensados para fondo OSCURO.** Sobre blanco se
+ *    lavan y los textos chicos de debajo de cada número hay que acercarse para
+ *    leerlos. Van más oscuros.
+ *  · **Lo que de verdad quita el aire de terminal** no es el color: es sacar la
+ *    monoespaciada y las rayas de monitor viejo.
+ *  · **El grosor importa tanto como el tamaño.** Una fuente fina, en tamaño
+ *    chico y sobre blanco, se ve aguada — sobre todo en los rótulos en
+ *    mayúsculas. Un peso medio los asienta sin engordar el texto corrido.
+ *
+ * LA ESCALA DE LETRA (lo importante)
+ *
+ * El panel tiene los tamaños escritos DENTRO de cada vista, en cientos de
+ * sitios. Cambiarlos uno por uno es tocar todo y arriesgar la maquetación, así
+ * que se re-mapean por CSS: cada tamaño chico sube ~2 px. Los más chiquitos
+ * suben más, porque son los que obligan a acercarse a la pantalla.
+ *
+ * ⚠️ **Esa lista NO se escribe a mano.** La saca `escala-de-letra.py`, que
+ * rastrea el código y encuentra los tamaños que se usan DE VERDAD, en las tres
+ * formas en que aparecen: `font-size:11px`, `font-size: 11px` (con espacio) y
+ * la clase `text-[10.5px]` de Tailwind. Lo intenté de memoria primero y fallé:
+ * se me quedaron fuera 8, 8.5, 9.5, 10.5, 11.5 y 12.5, y había textos que no
+ * cambiaban de tamaño. Si añades tamaños nuevos, vuelves a correr el script.
+ */
+
+export interface EnvTema {
+  PANEL_TEMA?: string;
+  TEMA_FUENTE?: string;
+  TEMA_COLOR?: string;
+  TEMA_COLOR2?: string;
+}
+
+const POR_DEFECTO = {
+  fuente: "Inter",
+  color: "#2f7fbf",
+  color2: "#a2670a",
+};
+
+/** Nombre de fuente -> el trozo que pide Google Fonts. */
+function enlaceDeFuente(fuente: string): string {
+  const familia = fuente.trim().replace(/\s+/g, "+");
+  return `<link href="https://fonts.googleapis.com/css2?family=${familia}:wght@400;500;600;700;800&display=swap" rel="stylesheet">`;
+}
+
+/**
+ * Escala de tamaños. La generas con `escala-de-letra.py` contra TU copia del
+ * panel y pegas aquí el resultado; esta es la que salió en la mía.
+ */
+const ESCALA = `
+    .text-\\\\[8px\\\\]{font-size:13.5px !important}
+    [style*="font-size:8.5px"],[style*="font-size: 8.5px"],.text-\\\\[8\\\\.5px\\\\]{font-size:13.5px !important}
+    [style*="font-size:9px"],[style*="font-size: 9px"],.text-\\\\[9px\\\\]{font-size:13.5px !important}
+    [style*="font-size:9.5px"],[style*="font-size: 9.5px"],.text-\\\\[9\\\\.5px\\\\]{font-size:13.5px !important}
+    [style*="font-size:10px"],[style*="font-size: 10px"],.text-\\\\[10px\\\\]{font-size:14px !important}
+    [style*="font-size:10.5px"],[style*="font-size: 10.5px"],.text-\\\\[10\\\\.5px\\\\]{font-size:14px !important}
+    [style*="font-size:11px"],[style*="font-size: 11px"],.text-\\\\[11px\\\\]{font-size:14.5px !important}
+    [style*="font-size:11.5px"],[style*="font-size: 11.5px"],.text-\\\\[11\\\\.5px\\\\]{font-size:14.5px !important}
+    [style*="font-size:12px"],[style*="font-size: 12px"],.text-\\\\[12px\\\\]{font-size:15px !important}
+    [style*="font-size:12.5px"],[style*="font-size: 12.5px"],.text-\\\\[12\\\\.5px\\\\]{font-size:15px !important}
+    [style*="font-size:13px"],[style*="font-size: 13px"],.text-\\\\[13px\\\\]{font-size:15.5px !important}
+    [style*="font-size:13.5px"],[style*="font-size: 13.5px"],.text-\\\\[13\\\\.5px\\\\]{font-size:15.5px !important}
+    [style*="font-size:14px"],[style*="font-size: 14px"],.text-\\\\[14px\\\\]{font-size:16.5px !important}
+    [style*="font-size:14.5px"],[style*="font-size: 14.5px"]{font-size:16.5px !important}
+    [style*="font-size:15px"],[style*="font-size: 15px"],.text-\\\\[15px\\\\]{font-size:17px !important}
+    .text-xs{font-size:15px !important}
+    .sb-sec{font-size:12.5px !important}`;
+
+/** El bloque para el <head>. Cadena vacía si el tema no está encendido. */
+export function temaClaro(env?: EnvTema): string {
+  if (env?.PANEL_TEMA !== "claro") return "";
+
+  const fuente = env.TEMA_FUENTE?.trim() || POR_DEFECTO.fuente;
+  const color = env.TEMA_COLOR?.trim() || POR_DEFECTO.color;
+  const color2 = env.TEMA_COLOR2?.trim() || POR_DEFECTO.color2;
+
+  return `
+  ${enlaceDeFuente(fuente)}
+  <style>
+    :root{
+      /* Fondo NO blanco puro (ver la nota de arriba) y tarjetas en blanco. */
+      --bg:#eef3f3; --panel:#ffffff; --panel2:#f7fafa; --raise:#e7efef;
+      --line:#dde6e6; --linelit:#c4d2d2;
+      --accent:${color}; --accent-2:${color2};
+      --accent-soft:color-mix(in srgb, ${color} 12%, transparent);
+      /* Grises oscurecidos: los de origen son para fondo oscuro. */
+      --cream:#2b2b2b; --muted:#4a5555; --dim:#616c6b;
+      --ok:#2f9e6f; --info:#2f7fbf; --bad:#c8503f; --violet:#7b5ea7;
+      --border:#e4eaea; --border-lit:#cbd6d6;
+      --green:#2f9e6f; --blue:#2f7fbf; --red:#c8503f;
+    }
+    /* Fuera la monoespaciada: es lo que más "terminal" se veía. */
+    html, body, input, textarea, select, button, .font-mono {
+      font-family:'${fuente}',-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif !important;
+    }
+    [style*="Space Grotesk"], .font-display {
+      font-family:'${fuente}',sans-serif !important; font-weight:800 !important;
+    }
+    body { font-size:15px; line-height:1.6; }
+    /* Las rayas de monitor viejo. */
+    .scanlines::before, .scanlines::after { display:none !important; }
+${ESCALA}
+    /* GROSOR: en tamaño chico y sobre blanco la letra se ve aguada, sobre todo
+       en los rótulos en mayúsculas. Un peso medio los asienta. */
+    [style*="letter-spacing"]{font-weight:600 !important}
+    th,thead td{font-weight:600 !important}
+  </style>`;
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -13,6 +13,12 @@ export interface Env {
   // Vars (member-set)
   BOT_NAME: string;
   PEER_BOTS?: string; // JSON [{name,url}] — otras instancias para el selector de proyectos
+  // TEMA CLARO DEL PANEL (opcional). Sin PANEL_TEMA el panel se ve igual que
+  // siempre: ver src/admin/views/temaClaro.ts.
+  PANEL_TEMA?: string; // "claro" para encenderlo
+  TEMA_FUENTE?: string; // familia de Google Fonts, ej. "Fira Sans"
+  TEMA_COLOR?: string; // color principal de la marca, ej. "#2f7fbf"
+  TEMA_COLOR2?: string; // color secundario
   WA_DAILY_TEMPLATE_CAP?: string; // tope diario de plantillas HSM (default 250 — tier 1 de Meta)
   BUSINESS_NAME: string;
   BOT_LANGUAGE: string;

--- a/test/admin/tema-claro.test.ts
+++ b/test/admin/tema-claro.test.ts
@@ -1,0 +1,104 @@
+/**
+ * TEMA CLARO DEL PANEL.
+ *
+ * Lo que se cuida aquí es que sea SEGURO de aplicar:
+ *   · sin la variable, el panel sale byte por byte como siempre;
+ *   · con ella, solo cambian color y tipografía — ninguna regla mueve, quita ni
+ *     reordena nada de la pantalla.
+ */
+import { describe, it, expect } from "vitest";
+import { temaClaro } from "../../src/admin/views/temaClaro";
+import { layout } from "../../src/admin/views/layout";
+import type { Env } from "../../src/env";
+
+const env = (extra: Partial<Env> = {}) =>
+  ({ BOT_NAME: "Bot", BUSINESS_NAME: "Negocio", BOT_TIER: "pro", ...extra }) as unknown as Env;
+
+describe("temaClaro", () => {
+  it("no devuelve nada si el tema no está encendido", () => {
+    expect(temaClaro(undefined)).toBe("");
+    expect(temaClaro(env())).toBe("");
+    expect(temaClaro(env({ PANEL_TEMA: "otro" } as Partial<Env>))).toBe("");
+  });
+
+  it("el panel queda IDÉNTICO sin la variable", () => {
+    const args = { title: "T", activeTab: "overview", body: "<p>hola</p>" };
+    expect(layout({ ...args, env: env() })).toBe(layout({ ...args, env: env() }));
+    // y no se cuela ni un rastro del tema
+    expect(layout({ ...args, env: env() })).not.toContain("PANEL_TEMA");
+    expect(layout({ ...args, env: env() })).not.toContain("fonts.googleapis.com/css2?family=Fira");
+  });
+
+  it("con la variable, se aplica al panel", () => {
+    const html = layout({
+      title: "T",
+      activeTab: "overview",
+      body: "<p>hola</p>",
+      env: env({ PANEL_TEMA: "claro" } as Partial<Env>),
+    });
+    expect(html).toContain("--panel:#ffffff");
+    expect(html).toContain("font-size:15px");
+  });
+
+  it("usa la fuente y los colores de la marca, y cae a un valor por defecto", () => {
+    const conMarca = temaClaro(
+      env({
+        PANEL_TEMA: "claro",
+        TEMA_FUENTE: "Fira Sans",
+        TEMA_COLOR: "#01aeab",
+        TEMA_COLOR2: "#a2670a",
+      } as Partial<Env>),
+    );
+    expect(conMarca).toContain("family=Fira+Sans");
+    expect(conMarca).toContain("--accent:#01aeab");
+    expect(conMarca).toContain("--accent-2:#a2670a");
+
+    const sinMarca = temaClaro(env({ PANEL_TEMA: "claro" } as Partial<Env>));
+    expect(sinMarca).toContain("family=Inter");
+    expect(sinMarca).toContain("--accent:#2f7fbf");
+  });
+
+  it("solo toca color y tipografía: nada mueve ni redimensiona cajas", () => {
+    // `line-height` es tipografía, no caja: se saca antes de mirar.
+    const css = temaClaro(env({ PANEL_TEMA: "claro" } as Partial<Env>)).replace(
+      /line-height:[^;}]+/g,
+      "",
+    );
+    for (const prohibida of [
+      "position:",
+      "width:",
+      "height:",
+      "margin:",
+      "padding:",
+      "flex",
+      "grid",
+      "top:",
+      "left:",
+      "float:",
+    ]) {
+      expect(css).not.toContain(prohibida);
+    }
+    // La ÚNICA excepción: se apaga la decoración de rayas del fondo, que no
+    // ocupa sitio ni empuja nada.
+    const displays = [...css.matchAll(/display:[^;!]+/g)].map((m) => m[0].trim());
+    expect(displays).toEqual(["display:none"]);
+  });
+
+  it("sube los tamaños chicos, que son los que obligan a acercarse", () => {
+    const css = temaClaro(env({ PANEL_TEMA: "claro" } as Partial<Env>));
+    // 11px es el tamaño más usado del panel
+    expect(css).toContain('[style*="font-size:11px"]');
+    // y con espacio después de los dos puntos, que también aparece en el código
+    expect(css).toContain('[style*="font-size: 11px"]');
+    // La regla de oro del re-mapeo: NINGÚN tamaño se hace más chico, y los
+    // más chiquitos son los que más suben (son los que obligan a acercarse).
+    const pares = [...css.matchAll(/font-size:([\d.]+)px"\][^{]*\{font-size:([\d.]+)px/g)].map(
+      (m) => ({ antes: Number(m[1]), despues: Number(m[2]) }),
+    );
+    expect(pares.length).toBeGreaterThan(10);
+    for (const { antes, despues } of pares) expect(despues).toBeGreaterThan(antes);
+    const masChico = pares.reduce((a, b) => (a.antes <= b.antes ? a : b));
+    const masGrande = pares.reduce((a, b) => (a.antes >= b.antes ? a : b));
+    expect(masChico.despues - masChico.antes).toBeGreaterThan(masGrande.despues - masGrande.antes);
+  });
+});


### PR DESCRIPTION
## Qué cambia

Un **tema claro opcional** para el panel, con la tipografía y los colores de cada miembro, y la **letra más grande**.

El panel viene oscuro y con monoespaciada. Se ve muy bien, pero cansa cuando lo tienes abierto ocho horas atendiendo clientes, y la letra de 11 px obliga a acercarse a la pantalla. Esto sale de usarlo así todos los días, con más gente del equipo metida ahí.

```toml
# wrangler.toml → [vars]
PANEL_TEMA  = "claro"        # sin esto, el panel queda idéntico
TEMA_FUENTE = "Fira Sans"    # opcional, cualquiera de Google Fonts
TEMA_COLOR  = "#2f7fbf"      # opcional
TEMA_COLOR2 = "#a2670a"      # opcional
```

## Por qué es seguro de mergear

1. **Es puramente aditivo.** Sin `PANEL_TEMA`, `layout()` devuelve exactamente lo mismo que antes. Hay una prueba que lo fija.
2. **Solo cambia color y tipografía.** Ninguna regla mueve, quita o reordena nada de la pantalla: otra prueba rechaza `position/width/height/margin/padding/flex/grid`. La única excepción permitida es apagar la decoración de rayas, que no ocupa sitio.

## La escala de letra

Los tamaños están escritos **dentro de cada vista**, en cientos de sitios. Cambiarlos uno por uno es tocar todo y arriesgar la maquetación, así que se re-mapean por CSS: cada tamaño chico sube ~2 px, y los más chiquitos suben más porque son los que obligan a acercarse. La prueba fija esa regla: ningún tamaño se hace más chico, y el más pequeño sube más que el más grande.

🔑 **Esa lista no está escrita a mano.** La genera `scripts/escala-de-letra.py`, que rastrea el código y saca los tamaños que se usan de verdad, en las **tres** formas en que aparecen: `font-size:11px`, `font-size: 11px` (con espacio) y la clase `text-[10.5px]` de Tailwind. Enumerarlos de memoria falló: quedaron fuera 8, 8.5, 9.5, 10.5, 11.5 y 12.5, y había textos que seguían chicos. Si se añaden tamaños nuevos al panel, se vuelve a correr el script.

## Cosas que solo se ven en pantalla (van comentadas en el archivo)

- **El fondo no puede ser blanco puro.** Si el fondo y las tarjetas son del mismo blanco, la pantalla queda como una hoja plana y deslumbra.
- **El color de marca puede no contrastar sobre blanco.** El ámbar que yo usaba se perdía en los enlaces; por eso el secundario se pasa aparte, ya oscurecido, en vez de reusar el de la web tal cual.
- **Los grises del panel están pensados para fondo oscuro.** Sobre blanco se lavan y los textos de debajo de cada número cuesta leerlos.
- **Lo que de verdad quita el aire de terminal** no es el color: es sacar la monoespaciada y las rayas.
- **El grosor importa tanto como el tamaño.** Una fuente fina, chica y sobre blanco se ve aguada, sobre todo en los rótulos en mayúsculas.

## Pruebas

`npx vitest run --no-file-parallelism` → **443 en verde**, incluidas 6 nuevas. `tsc --noEmit` limpio.

## Archivos

| Archivo | Qué es |
|---|---|
| `src/admin/views/temaClaro.ts` | nuevo — el tema |
| `scripts/escala-de-letra.py` | nuevo — genera la escala desde el código |
| `src/admin/views/layout.ts` | 2 líneas: import + enganche en el `<head>` |
| `src/env.ts` | declara las 4 variables opcionales |
| `test/admin/tema-claro.test.ts` | nuevo |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuevas funciones**
  * Añadido un tema claro opcional para el panel de administración.
  * Permite personalizar la fuente, los colores principales y secundarios.
  * Mejora la legibilidad al ampliar los tamaños de texto pequeños.
  * Incorpora tipografías de Google y ajustes visuales como colores, pesos y decoración de fondo.
  * El tema permanece desactivado por defecto y puede habilitarse mediante configuración del entorno.

* **Pruebas**
  * Verificada la activación, personalización e integración del tema sin alterar la apariencia predeterminada.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->