### PR TITLE
fix(panel): lo que le escribes AL BOT ya no parece un mensaje al cliente

### DIFF
--- a/src/admin/routes.ts
+++ b/src/admin/routes.ts
@@ -50,7 +50,7 @@ import { Db } from "../db/client";
 import { LeadsRepo, type Lead } from "../db/leads";
 import { TicketsRepo } from "../db/tickets";
 import { ConversationsRepo } from "../db/conversations";
-import { MessagesRepo } from "../db/messages";
+import { esNotaInterna, sinMarcaNota, MARCA_NOTA, MessagesRepo } from "../db/messages";
 import { SettingsRepo, SETTING_KEYS, type SettingKey } from "../db/settings";
 import { CONTROLS, levelToValue } from "./control-levels";
 import { systemPromptFromEnv } from "../system-prompt";
@@ -608,12 +608,18 @@ adminApp.post("/conversations/:id/resume", async (c) => {
   // has context when it picks the conversation back up. The summary field is
   // optional, so tolerate a request with no form body (formData() throws on an
   // empty/no-content-type body).
+  //
+  // La nota se guarda SOLO si de verdad se escribió algo. Antes se metía una de
+  // oficio, y en el hilo aparecía un mensaje que nadie había escrito.
+  //
+  // Y va MARCADA (MARCA_NOTA): no se le envió a nadie, así que ni el panel ni el
+  // bot pueden tratarla como un mensaje del chat.
   const form = await c.req.formData().catch(() => null);
-  const summary =
-    String(form?.get("summary") ?? "").trim() ||
-    "(El dueño habló con el cliente y resolvió la consulta.)";
-  const msgs = new MessagesRepo(new Db(c.env.DB));
-  await msgs.append(id, "owner", summary);
+  const summary = String(form?.get("summary") ?? "").trim();
+  if (summary) {
+    const msgs = new MessagesRepo(new Db(c.env.DB));
+    await msgs.append(id, "owner", `${MARCA_NOTA} ${summary}`);
+  }
   return c.redirect(`/admin/conversations?c=${encodeURIComponent(id)}`);
 });
 
@@ -638,12 +644,21 @@ adminApp.post("/conversations/:id/suggest", async (c) => {
   const msgs = new MessagesRepo(new Db(c.env.DB));
   const history = await msgs.lastN(c.req.param("id"), 20);
   const { model } = createModel(c.env, "fast", await loadLlmOverrides(c.env));
-  const aiMessages = history.map((m) => ({
-    role: (m.role === "tool" ? "user" : m.role === "owner" ? "assistant" : m.role) as
-      | "user"
-      | "assistant",
-    content: m.content,
-  }));
+  // Una nota interna no es una respuesta del bot: si se le pasa como suya, el
+  // co-pilot sugiere cosas que dan por hecho que el cliente leyó algo que nunca vio.
+  const aiMessages = history.map((m) =>
+    m.role === "owner" && esNotaInterna(m.content)
+      ? {
+          role: "user" as const,
+          content: `(Nota interna del equipo. El cliente NO vio esto: ${sinMarcaNota(m.content)})`,
+        }
+      : {
+          role: (m.role === "tool" ? "user" : m.role === "owner" ? "assistant" : m.role) as
+            | "user"
+            | "assistant",
+          content: m.content,
+        },
+  );
   aiMessages.push({
     role: "user",
     content:

--- a/src/admin/views/conversations.ts
+++ b/src/admin/views/conversations.ts
@@ -18,6 +18,7 @@ import { SENTIMENT_BADGE } from "./insights";
 import { costOfUsage, type ModelId } from "../../pricing";
 import { channelLabel } from "../../channels/labels";
 import { layout } from "./layout";
+import { esNotaInterna, sinMarcaNota } from "../../db/messages";
 
 /** Tiempo relativo corto en español (ej. "hace 5 min", "hace 2 h", "hace 3 d"). */
 function ago(ms: number | null | undefined): string {
@@ -297,10 +298,22 @@ export async function renderThreadLive(env: Env, convId: string): Promise<string
         </div>`;
       }
 
+      // NOTA INTERNA: no salió por ningún canal, así que no puede parecer un
+      // mensaje enviado. Va centrada, en gris y con su rótulo — y sin el pie
+      // "Tú · enviado" que llevan los que sí salieron.
+      if (m.role === "owner" && esNotaInterna(m.content)) {
+        return `
+      <div style="align-self:center;max-width:78%;text-align:center;padding:2px 0">
+        <div style="font-size:9.5px;letter-spacing:.08em;text-transform:uppercase;color:var(--dim)">📝 Nota para el bot · la persona no la vio</div>
+        <div style="font-size:12px;color:var(--muted);margin-top:3px;white-space:pre-wrap">${escapeHtml(sinMarcaNota(m.content))}</div>
+        <div style="font-size:9.5px;color:var(--dim);margin-top:2px">${time}</div>
+      </div>`;
+      }
+
       const isOwner = m.role === "owner";
       const cost = turnCost(m);
       const meta = isOwner
-        ? `Tú · ${time}`
+        ? `Tú · enviado · ${time}`
         : [m.model_used ? modelShort(m.model_used) : null, cost || null, time].filter(Boolean).join(" · ");
       const bubbleBg = isOwner
         ? "background:rgba(245,166,35,.1);border:1px solid rgba(245,166,35,.4)"

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -4,7 +4,7 @@ import type { SystemModelMessage } from "ai";
 import type { Env } from "./env";
 import { Db } from "./db/client";
 import { ConversationsRepo } from "./db/conversations";
-import { MessagesRepo } from "./db/messages";
+import { esNotaInterna, sinMarcaNota, MessagesRepo } from "./db/messages";
 import { isPro } from "./config";
 import { resolveAgentConfig } from "./settings-loader";
 import { buildTools } from "./tools";
@@ -213,14 +213,25 @@ export class SupportAgent extends Agent<Env, SupportAgentState> {
 
     // Load history (last 20)
     const history = await msgs.lastN(convId, 20);
-    const aiMessages: any[] = history.slice(0, -1).map((m) => ({
-      role: (m.role === "tool"
-        ? "user"
-        : m.role === "owner"
-          ? "assistant"
-          : m.role) as "user" | "assistant",
-      content: m.content,
-    }));
+    const aiMessages: any[] = history.slice(0, -1).map((m) => {
+      // Una NOTA INTERNA no es algo que el bot dijo: es el equipo contándole qué
+      // pasó por fuera. Pasada como suya (owner → assistant), el bot cree
+      // habérselo dicho al cliente y puede darlo por sabido.
+      if (m.role === "owner" && esNotaInterna(m.content)) {
+        return {
+          role: "user" as const,
+          content: `(Nota interna del equipo. El cliente NO vio esto: ${sinMarcaNota(m.content)})`,
+        };
+      }
+      return {
+        role: (m.role === "tool"
+          ? "user"
+          : m.role === "owner"
+            ? "assistant"
+            : m.role) as "user" | "assistant",
+        content: m.content,
+      };
+    });
     // Build the LAST user message multimodal-aware: if it carries an
     // [IMAGE_URL: ...] marker AND we're on the Pro tier, attach the image.
     const lastUserMsg = history[history.length - 1];

--- a/src/db/messages.ts
+++ b/src/db/messages.ts
@@ -2,6 +2,30 @@ import { Db } from "./client";
 
 export type MessageRole = "user" | "assistant" | "tool" | "owner";
 
+/**
+ * NOTAS INTERNAS — lo que el equipo le cuenta AL BOT, y el cliente nunca ve.
+ *
+ * Al devolverle una conversación al bot se puede dejar una nota ("ya le
+ * confirmé el pago por fuera"). Esa nota se guarda como mensaje del dueño, y
+ * hasta ahora era indistinguible de un mensaje que SÍ se le envió al cliente:
+ * el panel la dibujaba igual, con el mismo pie. Es muy fácil escribir algo ahí
+ * y quedarse con la duda de si le llegó a la persona.
+ *
+ * Con la marca, la nota se puede tratar como lo que es en los CUATRO sitios
+ * donde ese texto se reusa: el hilo, el bot, el co-pilot y el flywheel.
+ *
+ * Las notas viejas (sin marca) se siguen viendo como antes.
+ */
+export const MARCA_NOTA = "[[NOTA]]";
+
+export function esNotaInterna(contenido: string): boolean {
+  return contenido.startsWith(MARCA_NOTA);
+}
+
+export function sinMarcaNota(contenido: string): string {
+  return esNotaInterna(contenido) ? contenido.slice(MARCA_NOTA.length).trim() : contenido;
+}
+
 export interface Message {
   id: string;
   conversation_id: string;

--- a/src/flywheel/detect.ts
+++ b/src/flywheel/detect.ts
@@ -16,7 +16,7 @@ import { generateText } from "ai";
 import type { Env } from "../env";
 import { Db } from "../db/client";
 import { InsightsRepo } from "../db/insights";
-import { MessagesRepo } from "../db/messages";
+import { esNotaInterna, sinMarcaNota, MessagesRepo } from "../db/messages";
 import { SuggestionsRepo } from "../db/suggestions";
 import { SettingsRepo, SETTING_KEYS } from "../db/settings";
 import { createModel } from "../llm/provider";
@@ -116,7 +116,11 @@ export async function detectLessons(env: Env, limit = 3): Promise<FlywheelResult
     try {
       const history = await msgs.lastN(conv.conversation_id, 30);
       const transcript = history
-        .map((m) => `${m.role === "user" ? "Cliente" : m.role === "owner" ? "Dueño" : "Bot"}: ${m.content.slice(0, 400)}`)
+        .map((m) =>
+          m.role === "owner" && esNotaInterna(m.content)
+            ? `Nota interna (el cliente NO la vio): ${sinMarcaNota(m.content).slice(0, 400)}`
+            : `${m.role === "user" ? "Cliente" : m.role === "owner" ? "Dueño" : "Bot"}: ${m.content.slice(0, 400)}`,
+        )
         .join("\n");
 
       const result = await generateText({

--- a/test/admin/notas-internas.test.ts
+++ b/test/admin/notas-internas.test.ts
@@ -1,0 +1,130 @@
+/**
+ * LO QUE LE ESCRIBES AL BOT NO PUEDE PARECER UN MENSAJE AL CLIENTE.
+ *
+ * Al devolverle una conversación al bot puedes dejarle una nota. Esa nota NO se
+ * le envía a nadie — pero el panel la dibujaba igual que un mensaje enviado, con
+ * el mismo pie, así que es facilísimo escribir algo ahí y quedarte con la duda
+ * de si le llegó a la persona.
+ *
+ * Lo que se cuida aquí:
+ *   · que la nota se guarde marcada y se dibuje como nota;
+ *   · que NO se invente una nota cuando no escribiste nada;
+ *   · y lo que de verdad importa: que los CUATRO consumidores de ese texto la
+ *     traten como nota y no como algo que el bot dijo.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { createTestMiniflare } from "../helpers/miniflareSetup";
+import { adminApp } from "../../src/admin/routes";
+import { Db } from "../../src/db/client";
+import { ConversationsRepo } from "../../src/db/conversations";
+import {
+  MessagesRepo,
+  MARCA_NOTA,
+  esNotaInterna,
+  sinMarcaNota,
+} from "../../src/db/messages";
+import type { Env } from "../../src/env";
+
+const PASSWORD = "secret123";
+const b64 = (s: string) =>
+  typeof btoa === "function" ? btoa(s) : Buffer.from(s, "utf-8").toString("base64");
+const AUTH = { Authorization: `Basic ${b64(`admin:${PASSWORD}`)}` };
+const FORM = { ...AUTH, "Content-Type": "application/x-www-form-urlencoded" };
+
+let env: Env;
+let convs: ConversationsRepo;
+let msgs: MessagesRepo;
+
+beforeEach(async () => {
+  const mf = await createTestMiniflare();
+  const d1 = (await mf.getD1Database("DB")) as any;
+  env = {
+    DB: d1,
+    BOT_NAME: "TestBot",
+    BUSINESS_NAME: "Negocio de Prueba",
+    BOT_LANGUAGE: "es",
+    BOT_TIER: "pro",
+    DASHBOARD_PASSWORD: PASSWORD,
+  } as unknown as Env;
+  const db = new Db(d1);
+  convs = new ConversationsRepo(db);
+  msgs = new MessagesRepo(db);
+});
+
+describe("la marca", () => {
+  it("reconoce y limpia una nota interna", () => {
+    expect(esNotaInterna(`${MARCA_NOTA} ya le confirmé el pago`)).toBe(true);
+    expect(sinMarcaNota(`${MARCA_NOTA} ya le confirmé el pago`)).toBe("ya le confirmé el pago");
+  });
+
+  it("un mensaje normal del dueño no es una nota", () => {
+    expect(esNotaInterna("Buenas, ya le respondo")).toBe(false);
+    expect(sinMarcaNota("Buenas, ya le respondo")).toBe("Buenas, ya le respondo");
+  });
+});
+
+describe("devolver la conversación al bot", () => {
+  it("guarda la nota MARCADA cuando escribiste algo", async () => {
+    const conv = await convs.getOrCreate("telegram", "u1");
+    await convs.setPausedUntil(conv.id, Date.now() + 60_000);
+    await adminApp.request(
+      `/conversations/${encodeURIComponent(conv.id)}/resume`,
+      { method: "POST", headers: FORM, body: new URLSearchParams({ summary: "le confirmé el pago" }) },
+      env,
+    );
+    const historia = await msgs.lastN(conv.id, 5);
+    const ultimo = historia[historia.length - 1];
+    expect(esNotaInterna(ultimo.content)).toBe(true);
+    expect(sinMarcaNota(ultimo.content)).toBe("le confirmé el pago");
+    expect(await convs.isPaused(conv.id)).toBe(false);
+  });
+
+  it("NO inventa una nota si no escribiste nada", async () => {
+    const conv = await convs.getOrCreate("telegram", "u2");
+    await convs.setPausedUntil(conv.id, Date.now() + 60_000);
+    await adminApp.request(
+      `/conversations/${encodeURIComponent(conv.id)}/resume`,
+      { method: "POST", headers: FORM, body: new URLSearchParams({ summary: "   " }) },
+      env,
+    );
+    expect(await msgs.lastN(conv.id, 5)).toHaveLength(0);
+    // pero el bot sí vuelve
+    expect(await convs.isPaused(conv.id)).toBe(false);
+  });
+});
+
+describe("cómo se ve en el hilo", () => {
+  it("la nota se dibuja como nota, y NO como un mensaje enviado", async () => {
+    const conv = await convs.getOrCreate("whatsapp", "51999", "Rosa");
+    await msgs.append(conv.id, "owner", `${MARCA_NOTA} le confirmé el pago`);
+    const html = await (
+      await adminApp.request(
+        `/conversations/thread/${encodeURIComponent(conv.id)}`,
+        { headers: AUTH },
+        env,
+      )
+    ).text();
+    expect(html).toContain("Nota para el bot");
+    expect(html).toContain("la persona no la vio");
+    expect(html).toContain("le confirmé el pago");
+    // la marca es de uso interno: no se le enseña a nadie
+    expect(html).not.toContain(MARCA_NOTA);
+    // y no lleva el pie de los mensajes que sí salieron
+    expect(html).not.toContain("Tú · enviado");
+  });
+
+  it("un mensaje del dueño que SÍ se envió se sigue viendo como enviado", async () => {
+    const conv = await convs.getOrCreate("whatsapp", "51888", "Rosa");
+    await msgs.append(conv.id, "owner", "Buenas, le respondo yo");
+    const html = await (
+      await adminApp.request(
+        `/conversations/thread/${encodeURIComponent(conv.id)}`,
+        { headers: AUTH },
+        env,
+      )
+    ).text();
+    expect(html).toContain("Tú · enviado");
+    expect(html).not.toContain("Nota para el bot");
+  });
+});


### PR DESCRIPTION
## El problema

Al devolver una conversación al bot puedes dejarle una nota. Esa nota **NO se le envía a nadie**: solo se guarda para que el bot retome con contexto.

Pero el hilo la dibujaba **idéntica a un mensaje enviado**, con el mismo pie (`Tú · hora`). Escribes algo ahí, lo ves aparecer en la conversación y das por hecho que le llegó al cliente.

Me pasó con un simple `"."`. Verificar que **no** se había enviado me costó revisar todos los adapters buscando quién puede mandar por un canal. En un panel donde atiendes clientes reales, dudar de si algo salió o no es lo peor que te puede pasar.

Y había un segundo problema: si no escribías nada, `/resume` metía una nota de oficio — *"(El dueño habló con el cliente y resolvió la consulta.)"* — o sea, un mensaje que nadie escribió, apareciendo en el chat.

## Qué cambia

- Las notas se guardan **marcadas** (`MARCA_NOTA` en `db/messages.ts`), con `esNotaInterna()` y `sinMarcaNota()`.
- `/resume` guarda la nota **solo si de verdad escribiste algo**.
- El hilo la dibuja centrada y en gris — *"📝 Nota para el bot · la persona no la vio"* — y los mensajes que **sí** salieron ahora dicen `Tú · enviado`.

## Lo que de verdad importa: los cuatro consumidores

Marcar el texto y pintarlo distinto es lo fácil. Acordarse de **todos** los sitios donde ese texto se reusa, no. Esto es lo que casi se me escapa:

| Dónde | Antes | Ahora |
|---|---|---|
| `agent.ts` | `owner → assistant`: el bot creía habérselo dicho al cliente y podía darlo por sabido | lo recibe como *"Nota interna del equipo. El cliente NO vio esto"* |
| `routes.ts` (co-pilot "Sugerir") | igual | igual |
| `flywheel/detect.ts` | sacaba lecciones de estilo de un texto que ni siquiera es una respuesta | lo etiqueta como nota interna |
| el hilo del panel | burbuja idéntica a un mensaje enviado | nota, centrada y en gris |

## Compatibilidad

Las notas **viejas** (sin marca) se siguen viendo como antes. Eran mensajes que sí se enviaron, así que está bien que parezcan mensajes.

## Pruebas

`npx vitest run --no-file-parallelism` → **443 en verde**, incluidas 6 nuevas (`test/admin/notas-internas.test.ts`). `tsc --noEmit` limpio.

Entre ellas, las dos que fijan lo importante: que **no** se invente una nota cuando no escribiste nada, y que un mensaje del dueño que sí se envió se siga viendo como enviado.
