### PR TITLE
feat(panel): un color propio para cada contacto en la bandeja

### DIFF
--- a/src/admin/views/avatarContacto.ts
+++ b/src/admin/views/avatarContacto.ts
@@ -1,0 +1,64 @@
+/**
+ * UN COLOR PROPIO PARA CADA CONTACTO.
+ *
+ * En la lista de conversaciones todos los contactos se veían igual, y para
+ * encontrar a alguien había que leer nombre por nombre. Ahora cada uno tiene su
+ * cuadradito de color con sus iniciales — y es SIEMPRE el mismo color, porque
+ * sale de su propio número (o su id de canal), no de un aleatorio ni del orden
+ * en la lista. El mismo color en la bandeja y dentro del chat.
+ *
+ * ¿Y la foto de perfil de verdad? NO SE PUEDE, y no es culpa del panel:
+ * WhatsApp Cloud API entrega por mensaje el nombre que la persona se puso y su
+ * número (`contacts[].profile.name` y `wa_id`), nada más. Meta no expone la foto
+ * de quien te escribe, ni con la cuenta verificada. Telegram sí tendría, pero
+ * casi nadie atiende clientes por ahí. Así que esto es lo más cerca que se
+ * llega, y funciona igual de bien para reconocer a alguien de un vistazo.
+ *
+ * ⚠️ LA TRAMPA DE LAS INICIALES: hay que saltarse los guiones y los signos. Un
+ * contacto guardado como "Ana - Tienda Central" daba "A-" en vez de "AT",
+ * porque el guion contaba como palabra.
+ */
+
+/** Escapa texto que va dentro de HTML. Usa el de tu proyecto si ya tienes uno. */
+function escapeHtml(s: string): string {
+  return s.replace(
+    /[&<>"']/g,
+    (ch) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[ch]!),
+  );
+}
+
+/** Las dos primeras letras útiles. Ignora guiones, signos y espacios de más. */
+export function initialsOf(label: string): string {
+  const palabras = (label ?? "")
+    .split(/[\s\-–—_·|]+/)
+    .map((p) => p.replace(/[^\p{L}\p{N}]/gu, ""))
+    .filter(Boolean);
+  if (!palabras.length) return "?";
+  if (palabras.length === 1) return palabras[0].slice(0, 2).toUpperCase();
+  return (palabras[0][0] + palabras[1][0]).toUpperCase();
+}
+
+/**
+ * Color estable a partir de una semilla (el número o el id del contacto).
+ *
+ * Saturación y luz FIJAS a propósito: solo se mueve el tono. Así ningún
+ * contacto sale de un color chillón ni de uno tan pálido que no se lea, y
+ * ninguno compite con el color de marca del panel.
+ */
+export function colorDeContacto(semilla: string): { fondo: string; texto: string } {
+  let h = 0;
+  for (let i = 0; i < semilla.length; i++) h = (h * 31 + semilla.charCodeAt(i)) % 360;
+  return { fondo: `hsl(${h} 42% 42%)`, texto: "#fff" };
+}
+
+/** El cuadradito listo para pegar en la lista o en la cabecera del chat. */
+export function avatarContacto(etiqueta: string, semilla: string, tamano: number): string {
+  const c = colorDeContacto(semilla);
+  return (
+    `<div title="${escapeHtml(etiqueta)}" style="width:${tamano}px;height:${tamano}px;flex:none;` +
+    `background:${c.fondo};color:${c.texto};border:1px solid rgba(0,0,0,.18);` +
+    `display:flex;align-items:center;justify-content:center;` +
+    `font-size:${Math.round(tamano * 0.38)}px;font-weight:700;letter-spacing:.02em">` +
+    `${escapeHtml(initialsOf(etiqueta))}</div>`
+  );
+}

--- a/src/admin/views/conversations.ts
+++ b/src/admin/views/conversations.ts
@@ -18,6 +18,7 @@ import { SENTIMENT_BADGE } from "./insights";
 import { costOfUsage, type ModelId } from "../../pricing";
 import { channelLabel } from "../../channels/labels";
 import { layout } from "./layout";
+import { avatarContacto } from "./avatarContacto";
 
 /** Tiempo relativo corto en español (ej. "hace 5 min", "hace 2 h", "hace 3 d"). */
 function ago(ms: number | null | undefined): string {
@@ -94,13 +95,6 @@ const smallPill = (color: string) =>
   `font-size:9px;letter-spacing:.03em;color:${color};border:1px solid ${color};padding:1px 6px`;
 const statusBadge = (color: string) =>
   `font-size:10px;letter-spacing:.03em;color:${color};border:1px solid ${color};padding:2px 8px`;
-
-/** Two-letter avatar initials from a display name (or channel-id fallback). */
-function initialsOf(label: string): string {
-  const parts = label.trim().split(/\s+/).filter(Boolean);
-  if (parts.length === 0) return "?";
-  return parts.slice(0, 2).map((w) => w[0]?.toUpperCase() ?? "").join("") || "?";
-}
 
 /** WhatsApp gets info-blue, every other channel gets accent-2 amber — mirrors the mockup's WA/other split. */
 function channelColor(channel: string): string {
@@ -184,12 +178,12 @@ export async function renderInboxList(env: Env, p: InboxParams): Promise<string>
       const selected = r.id === p.selectedId;
       const name = escapeHtml(r.display_name ?? r.channel_user_id ?? "—");
       const preview = escapeHtml((r.last_msg ?? "").replace(/\s+/g, " ").slice(0, 60));
-      const initials = initialsOf(r.display_name ?? r.channel_user_id ?? "?");
+      const etiqueta = r.display_name ?? r.channel_user_id ?? "?";
       const chanColor = channelColor(r.channel);
 
       return `
       <a href="${inboxUrl(p, r.id)}" class="convrow" style="display:flex;gap:11px;padding:12px 14px;border-bottom:1px solid var(--line);cursor:pointer;${selected ? "background:var(--panel2);border-left:2px solid var(--accent)" : "border-left:2px solid transparent"}">
-        <div style="width:34px;height:34px;flex:none;background:var(--raise);border:1px solid var(--linelit);display:flex;align-items:center;justify-content:center;font-size:11.5px;font-weight:700;color:var(--accent)">${initials}</div>
+        ${avatarContacto(etiqueta, r.channel_user_id ?? r.id, 34)}
         <div style="min-width:0;flex:1">
           <div style="display:flex;align-items:center;gap:6px">
             <span style="font-size:12.5px;font-weight:600;white-space:nowrap;text-overflow:ellipsis;overflow:hidden;color:var(--cream)">${name}</span>

--- a/src/admin/views/overview.ts
+++ b/src/admin/views/overview.ts
@@ -12,6 +12,7 @@ import { InsightsRepo } from "../../db/insights";
 import { SuggestionsRepo } from "../../db/suggestions";
 import { channelLabel } from "../../channels/labels";
 import { getNiche } from "../../niches";
+import { avatarContacto } from "./avatarContacto";
 
 function esc(s: string): string {
   return s.replace(
@@ -29,13 +30,6 @@ function ago(ms: number | null | undefined): string {
   const h = Math.floor(min / 60);
   if (h < 24) return `hace ${h} h`;
   return `hace ${Math.floor(h / 24)} d`;
-}
-
-/** Two-letter avatar initials from a display name (or channel-id fallback). */
-function initialsOf(label: string): string {
-  const parts = label.trim().split(/\s+/).filter(Boolean);
-  if (parts.length === 0) return "?";
-  return parts.slice(0, 2).map((w) => w[0]?.toUpperCase() ?? "").join("") || "?";
 }
 
 /** "auto" or the concrete model id the agent is pinned to. */
@@ -197,12 +191,12 @@ export async function renderOverview(env: Env): Promise<string> {
       .map((c) => {
         const label = c.display_name ?? c.channel_user_id ?? "—";
         const name = esc(label);
-        const initials = initialsOf(label);
+
         const preview = esc((c.last_msg ?? "").replace(/\s+/g, " ").slice(0, 60)) || "—";
         const chanColor = c.channel === "twilio" || c.channel === "whatsapp" ? "var(--info)" : "var(--accent-2)";
         return `
         <a href="/admin/conversations?c=${encodeURIComponent(c.id)}" class="convrow flex items-center gap-3" style="padding:12px 18px;border-top:1px solid var(--line);cursor:pointer">
-          <div class="flex items-center justify-center flex-none" style="width:36px;height:36px;background:var(--raise);border:1px solid var(--linelit);font-size:12px;font-weight:700;color:var(--accent)">${initials}</div>
+          ${avatarContacto(label, c.channel_user_id ?? c.id, 36)}
           <div class="flex-1" style="min-width:0">
             <div class="flex items-center gap-2">
               <span class="text-[13px] font-semibold text-cream">${name}</span>

--- a/test/admin/avatar-contacto.test.ts
+++ b/test/admin/avatar-contacto.test.ts
@@ -1,0 +1,69 @@
+/**
+ * UN COLOR PROPIO PARA CADA CONTACTO.
+ *
+ * En la bandeja todos los avatares eran del mismo gris, así que para encontrar
+ * a alguien había que leer nombre por nombre. Ahora cada contacto tiene su
+ * color, y es SIEMPRE el mismo porque sale de su propio id de canal.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  initialsOf,
+  colorDeContacto,
+  avatarContacto,
+} from "../../src/admin/views/avatarContacto";
+
+describe("iniciales", () => {
+  it("saca dos letras de un nombre normal", () => {
+    expect(initialsOf("Rosa Quispe")).toBe("RQ");
+  });
+
+  it("con una sola palabra usa las dos primeras letras", () => {
+    expect(initialsOf("Rosa")).toBe("RO");
+  });
+
+  // La trampa: un contacto guardado como "Ana - Tienda Central" daba "A-".
+  it("se salta los guiones y los signos", () => {
+    expect(initialsOf("Ana - Tienda Central")).toBe("AT");
+    expect(initialsOf("Ana — Tienda")).toBe("AT");
+    expect(initialsOf("Ana_Tienda")).toBe("AT");
+  });
+
+  it("aguanta lo vacío y lo raro", () => {
+    expect(initialsOf("")).toBe("?");
+    expect(initialsOf("   ")).toBe("?");
+    expect(initialsOf("···")).toBe("?");
+  });
+});
+
+describe("color", () => {
+  it("el mismo contacto SIEMPRE recibe el mismo color", () => {
+    expect(colorDeContacto("51999888777")).toEqual(colorDeContacto("51999888777"));
+  });
+
+  it("contactos distintos reciben colores distintos", () => {
+    const a = colorDeContacto("51999888777").fondo;
+    const b = colorDeContacto("51911222333").fondo;
+    expect(a).not.toBe(b);
+  });
+
+  it("la saturación y la luz son fijas: ningún color chillón ni ilegible", () => {
+    for (const semilla of ["a", "51999888777", "telegram:42", "x".repeat(50)]) {
+      expect(colorDeContacto(semilla).fondo).toMatch(/^hsl\(\d{1,3} 42% 42%\)$/);
+    }
+  });
+});
+
+describe("el avatar", () => {
+  it("trae las iniciales, el color y el tamaño pedido", () => {
+    const html = avatarContacto("Rosa Quispe", "51999888777", 34);
+    expect(html).toContain(">RQ<");
+    expect(html).toContain(colorDeContacto("51999888777").fondo);
+    expect(html).toContain("width:34px");
+  });
+
+  it("escapa el nombre: no se puede colar HTML por ahí", () => {
+    const html = avatarContacto('<img src=x onerror=alert(1)>', "s", 30);
+    expect(html).not.toContain("<img");
+    expect(html).toContain("&lt;img");
+  });
+});


### PR DESCRIPTION
## Qué cambia

Todos los avatares de la bandeja eran del **mismo gris**, así que para encontrar a alguien había que leer nombre por nombre. Ahora cada contacto tiene **su** color.

Y es **siempre el mismo**, porque sale de su propio id de canal — no de un aleatorio ni del orden en la lista. El mismo color en la bandeja y en el Resumen.

La saturación y la luz son **fijas** a propósito: solo se mueve el tono. Así ningún contacto sale de un color chillón ni de uno tan pálido que no se lea, y ninguno compite con el color de marca del panel.

## De paso, un bug de las iniciales

`initialsOf()` partía solo por espacios, así que un contacto guardado como **"Ana - Tienda Central"** daba **"A-"** en vez de "AT". Ahora también parte por guiones y descarta los signos.

Y se quita una duplicación: `initialsOf()` estaba escrita **dos veces, idéntica**, en `conversations.ts` y en `overview.ts`. Ahora vive en un solo sitio.

## Sobre la foto de perfil de verdad

No se puede, y no es cosa del panel: WhatsApp Cloud API entrega por mensaje el nombre que la persona se puso y su número (`contacts[].profile.name`, `wa_id`), nada más. Meta no expone la foto de quien te escribe **ni con la cuenta verificada**. Telegram sí tendría, pero casi nadie atiende clientes por ahí.

Esto es lo más cerca que se llega, y para reconocer a alguien de un vistazo funciona igual de bien.

## Pruebas

`npx vitest run --no-file-parallelism` → **446 en verde**, incluidas 9 nuevas. `tsc --noEmit` limpio.

Entre ellas: que el mismo contacto reciba siempre el mismo color, que la saturación y la luz no se muevan nunca, el caso del guion, y que el nombre se escape (no se puede colar HTML por ahí).
