### PR TITLE
fix(panel): no mostrar la etiqueta "Neutral" en la cabecera del chat

### DIFF
--- a/src/admin/views/conversations.ts
+++ b/src/admin/views/conversations.ts
@@ -234,8 +234,18 @@ export async function renderThreadLive(env: Env, convId: string): Promise<string
     paused ? "⏸ bot pausado · tú tienes el control" : "🟢 bot activo"
   }</span>`;
 
+  // "NEUTRAL" NO SE MUESTRA. El analizador clasifica cómo quedó el cliente en
+  // cuatro casillas, y "neutral" es la de "no detecté nada": es la enorme
+  // mayoría de las conversaciones. Una etiqueta que sale casi siempre y no dice
+  // nada solo roba sitio en la barra y le quita fuerza a las que sí importan.
+  //
+  // Sin etiqueta = todo normal. Cuando aparezca una, significa algo.
+  // Las alertas del dueño no cambian: nunca dependieron de "neutral", y la
+  // lista de conversaciones ya filtraba así (solo frustrated/angry).
   const sentBadge =
-    insight?.sentiment && SENTIMENT_BADGE[insight.sentiment]
+    insight?.sentiment &&
+    insight.sentiment !== "neutral" &&
+    SENTIMENT_BADGE[insight.sentiment]
       ? `<span style="${statusBadge(SENTIMENT_COLOR[insight.sentiment])}">${SENTIMENT_BADGE[insight.sentiment].txt}</span>`
       : "";
 

--- a/test/admin/etiqueta-neutral.test.ts
+++ b/test/admin/etiqueta-neutral.test.ts
@@ -1,0 +1,83 @@
+/**
+ * LA ETIQUETA "NEUTRAL" NO SE MUESTRA.
+ *
+ * El analizador clasifica cómo quedó el cliente en cuatro casillas, y "neutral"
+ * es la de "no detecté nada": es la enorme mayoría de las conversaciones. Una
+ * etiqueta que sale casi siempre y no dice nada solo roba sitio y le quita
+ * fuerza a las que sí importan.
+ *
+ * La lista de conversaciones ya filtraba así (solo frustrated/angry); esto lo
+ * alinea en la cabecera del chat.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { createTestMiniflare } from "../helpers/miniflareSetup";
+import { adminApp } from "../../src/admin/routes";
+import { Db } from "../../src/db/client";
+import { ConversationsRepo } from "../../src/db/conversations";
+import type { Env } from "../../src/env";
+
+const PASSWORD = "secret123";
+const b64 = (s: string) =>
+  typeof btoa === "function" ? btoa(s) : Buffer.from(s, "utf-8").toString("base64");
+const AUTH = { Authorization: `Basic ${b64(`admin:${PASSWORD}`)}` };
+
+let env: Env;
+let db: Db;
+let convs: ConversationsRepo;
+
+beforeEach(async () => {
+  const mf = await createTestMiniflare();
+  const d1 = (await mf.getD1Database("DB")) as any;
+  env = {
+    DB: d1,
+    BOT_NAME: "TestBot",
+    BUSINESS_NAME: "Negocio de Prueba",
+    BOT_LANGUAGE: "es",
+    BOT_TIER: "pro",
+    DASHBOARD_PASSWORD: PASSWORD,
+  } as unknown as Env;
+  db = new Db(d1);
+  convs = new ConversationsRepo(db);
+});
+
+async function hiloCon(sentimiento: string) {
+  const conv = await convs.getOrCreate("whatsapp", `51${sentimiento}`, "Cliente");
+  await db.run(
+    "INSERT OR REPLACE INTO conversation_insights (conversation_id, analyzed_at, sentiment) VALUES (?, ?, ?)",
+    [conv.id, Date.now(), sentimiento],
+  );
+  return (
+    await adminApp.request(
+      `/conversations/thread/${encodeURIComponent(conv.id)}`,
+      { headers: AUTH },
+      env,
+    )
+  ).text();
+}
+
+describe("etiqueta de cómo quedó el cliente", () => {
+  it("«Neutral» no se muestra: no dice nada", async () => {
+    expect(await hiloCon("neutral")).not.toContain("Neutral");
+  });
+
+  it("las que sí dicen algo se siguen mostrando", async () => {
+    expect(await hiloCon("frustrated")).toContain("Frustrado");
+    expect(await hiloCon("angry")).toContain("Enojado");
+    expect(await hiloCon("positive")).toContain("Contento");
+  });
+
+  it("una conversación sin analizar tampoco muestra nada", async () => {
+    const conv = await convs.getOrCreate("whatsapp", "51000", "Cliente");
+    const html = await (
+      await adminApp.request(
+        `/conversations/thread/${encodeURIComponent(conv.id)}`,
+        { headers: AUTH },
+        env,
+      )
+    ).text();
+    for (const t of ["Neutral", "Frustrado", "Enojado", "Contento"]) {
+      expect(html).not.toContain(t);
+    }
+  });
+});


### PR DESCRIPTION
## Qué cambia

El analizador clasifica cómo quedó el cliente en cuatro casillas, y **"neutral" es la de "no detecté nada"**. En mi panel son **109 de 129 conversaciones — el 85 %**.

Una etiqueta que sale casi siempre y no dice nada solo roba sitio en la barra y le quita fuerza a las que sí importan.

**Sin etiqueta = todo normal.** Cuando aparezca una, significa algo y salta a la vista.

## Lo que NO cambia

- Las que sí dicen algo (**Frustrado**, **Enojado**, **Contento**) se siguen mostrando.
- Las **alertas al dueño** no cambian: nunca dependieron de "neutral".
- De hecho, la **lista** de conversaciones ya filtraba así (solo `frustrated`/`angry`). Esto solo alinea la cabecera del chat con lo que la lista ya hacía — antes eran incoherentes entre sí.

## Pruebas

`npx vitest run --no-file-parallelism` → **440 en verde**, incluidas 3 nuevas: que "Neutral" no salga, que las otras tres sí, y que una conversación sin analizar no muestre ninguna.
