### PR TITLE
feat(panel): buzón para que el equipo reporte cuando el bot contesta mal

### DIFF
--- a/src/admin/routes.ts
+++ b/src/admin/routes.ts
@@ -42,6 +42,8 @@ import { runFlywheel, getLessons, saveLessons } from "../flywheel/detect";
 import { applySuggestion, dismissSuggestion } from "../flywheel/apply";
 import { renderLeads, exportLeadsCsv } from "./views/leads";
 import { renderTickets } from "./views/tickets";
+import { renderReportes, reporteEnviado, reporteVacio } from "./views/reportes";
+import { ReportesRepo } from "../db/reportes";
 import { renderConfig } from "./views/config";
 import { renderConexiones } from "./views/conexiones";
 import { renderCampanas } from "./views/campanas";
@@ -359,6 +361,89 @@ adminApp.post("/agente/tools/:name/toggle", async (c) => {
 adminApp.get("/leads", async (c) => c.html(await renderLeads(c.env)));
 
 adminApp.get("/tickets", async (c) => c.html(await renderTickets(c.env)));
+
+// --- Buzón de reportes del equipo -------------------------------------------
+//
+// Quien atiende ve una respuesta mala del bot y la reporta ahí mismo. Se entra
+// por dos sitios —esta pestaña y el botón ⚑ del hilo— y ambos escriben aquí.
+
+adminApp.get("/reportes", async (c) =>
+  c.html(
+    await renderReportes(c.env, {
+      filtro: c.req.query("estado"),
+      enviado: c.req.query("enviado") === "1",
+    }),
+  ),
+);
+
+/**
+ * Crear un reporte. Responde de dos formas según de dónde venga:
+ *   · desde el hilo (htmx) → un fragmento de confirmación, sin recargar nada;
+ *   · desde la pestaña → redirect, y el reporte ya aparece en la lista.
+ */
+adminApp.post("/reportes", async (c) => {
+  const form = await c.req.formData().catch(() => null);
+  const texto = String(form?.get("texto") ?? "").trim();
+  const esHtmx = c.req.header("HX-Request") === "true";
+
+  if (!texto) {
+    return esHtmx ? c.html(reporteVacio()) : c.redirect("/admin/reportes");
+  }
+
+  const tipo = String(form?.get("tipo") ?? "error") === "sugerencia" ? "sugerencia" : "error";
+  const conversationId = String(form?.get("conversation_id") ?? "").trim() || null;
+  const reportadoPor = String(form?.get("reportado_por") ?? "").trim() || null;
+
+  await new ReportesRepo(new Db(c.env.DB)).crear({
+    tipo,
+    texto,
+    reportadoPor,
+    conversationId,
+  });
+
+  // Aviso al dueño por el mismo camino que los handoffs (Telegram/correo). Va
+  // en segundo plano a propósito: si Telegram tarda o falla, quien reportó no
+  // se queda esperando ni pierde el reporte, que YA está guardado.
+  const avisar = async () => {
+    const { notifyOwner } = await import("../tools/handoffHuman");
+    const origen = c.env.DASHBOARD_BASE_URL ?? "";
+    await notifyOwner(c.env, {
+      reason:
+        tipo === "sugerencia" ? "💡 Idea para el bot" : "⚠ Reporte: algo falló en el bot",
+      summary:
+        `${reportadoPor ? `${reportadoPor}: ` : ""}${texto}` +
+        (conversationId
+          ? `
+
+Chat: ${origen}/admin/conversations?c=${encodeURIComponent(conversationId)}`
+          : ""),
+      ticketId: "",
+    });
+  };
+  try {
+    c.executionCtx.waitUntil(
+      avisar().catch((e) => console.error("[reportes] no se pudo avisar al dueño:", e)),
+    );
+  } catch {
+    // sin executionCtx (pruebas): el reporte igual quedó guardado
+  }
+
+  return esHtmx
+    ? c.html(reporteEnviado(), 200, { "X-Reporte": "1" })
+    : c.redirect("/admin/reportes?enviado=1");
+});
+
+adminApp.post("/reportes/:id/resolver", async (c) => {
+  const form = await c.req.formData().catch(() => null);
+  const respuesta = String(form?.get("respuesta") ?? "").trim();
+  await new ReportesRepo(new Db(c.env.DB)).resolver(c.req.param("id"), respuesta);
+  return c.redirect("/admin/reportes");
+});
+
+adminApp.post("/reportes/:id/reabrir", async (c) => {
+  await new ReportesRepo(new Db(c.env.DB)).reabrir(c.req.param("id"));
+  return c.redirect("/admin/reportes");
+});
 
 // Conexiones: mapa de canales con estado verde/gris (paso 4 del onboarding).
 adminApp.get("/conexiones", (c) => c.html(renderConexiones(c.env)));

--- a/src/admin/views/conversations.ts
+++ b/src/admin/views/conversations.ts
@@ -18,6 +18,7 @@ import { SENTIMENT_BADGE } from "./insights";
 import { costOfUsage, type ModelId } from "../../pricing";
 import { channelLabel } from "../../channels/labels";
 import { layout } from "./layout";
+import { formularioReporte } from "./reportes";
 
 /** Tiempo relativo corto en español (ej. "hace 5 min", "hace 2 h", "hace 3 d"). */
 function ago(ms: number | null | undefined): string {
@@ -257,6 +258,21 @@ export async function renderThreadLive(env: Env, convId: string): Promise<string
       ⏸ Pausar bot aquí
     </button>`;
 
+  // REPORTAR DESDE EL CHAT — el caso de uso real del buzón. Quien atiende ve una
+  // respuesta mala y la reporta AQUÍ MISMO, con el chat ya enganchado: no tiene
+  // que ir a otra pestaña a explicar de qué conversación hablaba.
+  //
+  // Es un <details> con el formulario dentro, para no sacar a nadie del hilo.
+  const botonReportar = `
+    <details style="position:relative">
+      <summary class="chip" style="cursor:pointer;list-style:none;font-size:11px;color:var(--bad);background:transparent;border:1px solid var(--bad);padding:6px 11px;display:inline-flex;align-items:center;gap:6px;white-space:nowrap"
+               title="Avisar de una respuesta mala o proponer una mejora">⚑ Reportar</summary>
+      <div style="position:absolute;right:0;z-index:10;margin-top:8px;width:330px;max-width:78vw;background:var(--panel);border:1px solid var(--linelit);box-shadow:6px 6px 0 rgba(0,0,0,.4);padding:13px">
+        <p style="font-size:11.5px;color:var(--muted);margin:0 0 9px;line-height:1.5">¿El bot respondió mal aquí? Cuéntalo y queda guardado en el <b style="color:var(--cream)">Buzón</b> con el enlace a este chat.</p>
+        ${formularioReporte({ conversationId: conv.id, htmx: true, compacto: true })}
+      </div>
+    </details>`;
+
   const header = `
   <div style="display:flex;flex-wrap:wrap;align-items:center;gap:8px;padding:12px 16px;border-bottom:1px solid var(--line);background:var(--panel)">
     <span style="font-family:'Space Grotesk';font-weight:600;font-size:14px;color:var(--cream)">${escapeHtml(conv.display_name ?? conv.channel_user_id)}</span>
@@ -265,6 +281,7 @@ export async function renderThreadLive(env: Env, convId: string): Promise<string
     ${sentBadge}
     ${openTicket > 0 ? `<span style="${statusBadge("var(--accent-2)")}">🔔 ticket abierto</span>` : ""}
     ${controls}
+    ${botonReportar}
   </div>`;
 
   // Messages, DESC in the DOM + column-reverse = pinned to bottom.

--- a/src/admin/views/layout.ts
+++ b/src/admin/views/layout.ts
@@ -40,6 +40,7 @@ const NAV: Section[] = [
       { id: "conversations", label: "Conversaciones", href: "/admin/conversations", icon: "messages-square" },
       { id: "leads", label: "Leads", href: "/admin/leads", icon: "user-plus" },
       { id: "tickets", label: "Tickets", href: "/admin/tickets", icon: "life-buoy" },
+      { id: "reportes", label: "Buzón", href: "/admin/reportes", icon: "inbox" },
       { id: "campanas", label: "Campañas", href: "/admin/campanas", icon: "megaphone" },
     ],
   },

--- a/src/admin/views/reportes.ts
+++ b/src/admin/views/reportes.ts
@@ -1,0 +1,246 @@
+/**
+ * BUZÓN — donde el equipo reporta fallas del bot y propone mejoras.
+ *
+ * La idea: que cualquiera del equipo pueda avisar
+ * cuando el bot contesta mal, igual que en los demás sistemas de el negocio.
+ *
+ * Dos puertas de entrada, el mismo buzón:
+ *   1. Esta pestaña — el formulario general ("se me ocurre…", "ayer falló…").
+ *   2. El botón "⚑ Reportar" del hilo de una conversación — el caso de verdad:
+ *      la secretaria ve una respuesta mala y la reporta EN EL MOMENTO, con el
+ *      chat ya enganchado para poder ir a leerlo después.
+ *
+ * Por qué no se reusó lo que ya existía: `tickets` los abre el BOT cuando pide
+ * ayuda humana (y esas conversaciones salen marcadas con 🔔 en la bandeja), y
+ * "Mejoras" es lo que propone la IA. Ver schema.sql y db/reportes.ts.
+ */
+import type { Env } from "../../env";
+import { Db } from "../../db/client";
+import { ReportesRepo, type Reporte, type EstadoReporte } from "../../db/reportes";
+import { layout } from "./layout";
+/** Igual que en Tickets: la fecha en local, sin dependencias nuevas. */
+const fechaHoraLarga = (ms: number) => new Date(ms).toLocaleString("es-MX");
+
+function esc(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]!));
+}
+
+const COLOR_TIPO: Record<string, string> = {
+  error: "var(--bad)",
+  sugerencia: "var(--info)",
+};
+
+const ETIQUETA_TIPO: Record<string, string> = {
+  error: "⚠ Algo falló",
+  sugerencia: "💡 Idea",
+};
+
+/**
+ * El nombre de quien reporta se recuerda en el navegador.
+ *
+ * El equipo va a usar esto varias veces al día: pedirles el
+ * nombre cada vez es la forma más rápida de que dejen de escribirlo (o de que
+ * pongan cualquier cosa). Se guarda solo en SU navegador — no viaja a ningún
+ * lado ni se comparte entre computadoras.
+ */
+export const RECORDAR_NOMBRE = `
+<script>
+(function () {
+  var LLAVE = "forja-quien-reporta";
+  function aplicar() {
+    var guardado = "";
+    try { guardado = localStorage.getItem(LLAVE) || ""; } catch (e) { return; }
+    document.querySelectorAll("input[name=reportado_por]").forEach(function (i) {
+      if (!i.value && guardado) {
+        i.value = guardado;
+        // Y pasa a ser "el valor con el que nació el campo". Si no, el cuadro
+        // de ⚑ Reportar creería que la persona ya escribió algo y se negaría a
+        // cerrarse con un clic afuera — solo porque nos adelantamos a poner su
+        // nombre. (Se detectó probándolo en el navegador, 10/08/2026.)
+        i.defaultValue = guardado;
+      }
+    });
+  }
+  function recordar(e) {
+    var f = e.target;
+    if (!f || !f.matches || !f.matches("form")) return;
+    var i = f.querySelector("input[name=reportado_por]");
+    if (i && i.value.trim()) { try { localStorage.setItem(LLAVE, i.value.trim()); } catch (err) {} }
+  }
+  document.addEventListener("DOMContentLoaded", aplicar);
+  document.addEventListener("submit", recordar, true);
+  document.body.addEventListener("htmx:afterSwap", aplicar);
+  aplicar();
+})();
+</script>`;
+
+const ESTILO_CAMPO =
+  "width:100%;background:var(--bg);border:1px solid var(--line);color:var(--cream);padding:9px 12px;font-size:12.5px;font-family:inherit;outline:none";
+
+/**
+ * El formulario para dejar un reporte. El mismo en la pestaña y dentro de una
+ * conversación; lo que cambia es si trae el chat enganchado y cómo responde.
+ *
+ * - En la pestaña va como formulario normal: al enviar, la página se recarga y
+ *   el reporte ya aparece abajo en la lista.
+ * - En el hilo va por htmx (`hx-post`), porque ahí NO se puede recargar la
+ *   página: el equipo está leyendo esa conversación. Ojo, esto no es un capricho
+ *   de estilo — con un POST normal la respuesta reemplazaría toda la pantalla
+ *   por un pedacito de HTML.
+ */
+export function formularioReporte(opts: {
+  conversationId?: string | null;
+  htmx?: boolean;
+  compacto?: boolean;
+}): string {
+  const conv = opts.conversationId ?? "";
+  const envio = opts.htmx
+    ? `hx-post="/admin/reportes" hx-target="#estado-reporte" hx-swap="innerHTML"
+       hx-on::after-request="if(event.detail.xhr.getResponseHeader('X-Reporte')==='1')this.reset()"`
+    : `method="POST" action="/admin/reportes"`;
+  const placeholder = opts.conversationId
+    ? "¿Qué pasó en este chat? Ej. le dijo que el taller es gratis y no lo es."
+    : "Cuéntanos qué pasó o qué se te ocurre. Mientras más concreto, mejor.";
+
+  return `
+  <form ${envio} style="display:flex;flex-direction:column;gap:9px">
+    ${conv ? `<input type="hidden" name="conversation_id" value="${esc(conv)}">` : ""}
+    <div style="display:flex;gap:8px;flex-wrap:wrap">
+      <label class="chip" style="cursor:pointer;display:inline-flex;align-items:center;gap:6px;font-size:11.5px;padding:6px 11px;border:1px solid var(--linelit);color:var(--muted)">
+        <input type="radio" name="tipo" value="error" checked style="accent-color:var(--bad)"> ⚠ Algo falló
+      </label>
+      <label class="chip" style="cursor:pointer;display:inline-flex;align-items:center;gap:6px;font-size:11.5px;padding:6px 11px;border:1px solid var(--linelit);color:var(--muted)">
+        <input type="radio" name="tipo" value="sugerencia" style="accent-color:var(--info)"> 💡 Se me ocurre algo
+      </label>
+    </div>
+    <textarea name="texto" rows="${opts.compacto ? 3 : 4}" required maxlength="2000"
+              placeholder="${esc(placeholder)}"
+              style="${ESTILO_CAMPO};resize:vertical"></textarea>
+    <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+      <input name="reportado_por" maxlength="60" placeholder="Tu nombre"
+             autocomplete="off" style="${ESTILO_CAMPO};flex:1;min-width:150px">
+      <button type="submit" class="bigbtn font-display font-bold text-[12px] cursor-pointer"
+              style="background:var(--accent);border:1px solid var(--accent);color:#1a1206;box-shadow:3px 3px 0 var(--linelit);padding:9px 18px;white-space:nowrap">
+        Enviar reporte
+      </button>
+    </div>
+    ${opts.htmx ? `<div id="estado-reporte" style="font-size:11.5px;min-height:1rem;color:var(--muted)"></div>` : ""}
+  </form>`;
+}
+
+/** Lo que ve quien reporta desde el hilo, justo después de enviar. */
+export function reporteEnviado(): string {
+  return `<span style="color:var(--ok)">✓ Reporte enviado. Queda guardado en el Buzón — gracias.</span>`;
+}
+
+export function reporteVacio(): string {
+  return `<span style="color:var(--bad)">✗ Escribe qué pasó antes de enviar.</span>`;
+}
+
+// --- Tarjeta de un reporte ----------------------------------------------------
+
+function tarjeta(r: Reporte): string {
+  const color = COLOR_TIPO[r.tipo] ?? "var(--muted)";
+  const etiqueta = ETIQUETA_TIPO[r.tipo] ?? r.tipo;
+  const resuelto = r.estado === "resuelto";
+  const quien = r.reportado_por ? esc(r.reportado_por) : "alguien del equipo";
+
+  const enlaceChat = r.conversation_id
+    ? `<a href="/admin/conversations?c=${encodeURIComponent(r.conversation_id)}"
+          style="font-size:11.5px;color:var(--accent);display:inline-flex;align-items:center;gap:5px">
+         💬 Ver la conversación
+       </a>`
+    : "";
+
+  const pie = resuelto
+    ? `<div style="border-top:1px solid var(--line);margin-top:10px;padding-top:10px;display:flex;align-items:flex-start;gap:8px;flex-wrap:wrap">
+         <div style="flex:1;min-width:180px">
+           <div style="font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--ok)">Resuelto${r.resuelto_at ? ` · ${esc(fechaHoraLarga(r.resuelto_at))}` : ""}</div>
+           ${r.respuesta ? `<p style="margin:4px 0 0;font-size:12.5px;color:var(--muted);line-height:1.5">${esc(r.respuesta)}</p>` : ""}
+         </div>
+         <form method="POST" action="/admin/reportes/${esc(r.id)}/reabrir">
+           <button class="chip" style="font-size:11px;background:transparent;border:1px dashed var(--linelit);color:var(--dim);padding:6px 11px;cursor:pointer">↺ Reabrir</button>
+         </form>
+       </div>`
+    : `<form method="POST" action="/admin/reportes/${esc(r.id)}/resolver"
+             style="border-top:1px solid var(--line);margin-top:10px;padding-top:10px;display:flex;gap:8px;flex-wrap:wrap">
+         <input name="respuesta" maxlength="1000" placeholder="¿Qué se hizo? (opcional)"
+                style="${ESTILO_CAMPO};flex:1;min-width:180px">
+         <button class="bigbtn font-display font-bold text-[11.5px] cursor-pointer"
+                 style="background:var(--accent);border:1px solid var(--accent);color:#1a1206;box-shadow:3px 3px 0 var(--linelit);padding:9px 16px;white-space:nowrap">Marcar resuelto</button>
+       </form>`;
+
+  return `
+  <div class="tkcard bg-panel border border-line" style="padding:15px 17px;margin-bottom:12px;${resuelto ? "opacity:.72" : ""}">
+    <div style="display:flex;align-items:center;justify-content:space-between;gap:10px;margin-bottom:8px;flex-wrap:wrap">
+      <div style="display:flex;align-items:center;gap:8px;min-width:0;flex-wrap:wrap">
+        <span style="font-size:10px;letter-spacing:.04em;color:${color};border:1px solid ${color};padding:1px 7px;flex:none">${etiqueta}</span>
+        <span class="text-muted" style="font-size:11.5px">${quien}</span>
+        ${enlaceChat}
+      </div>
+      <span class="text-dim" style="font-size:11px;flex:none">${esc(fechaHoraLarga(r.created_at))}</span>
+    </div>
+    <p class="text-cream" style="margin:0;font-size:13px;line-height:1.55;white-space:pre-wrap;overflow-wrap:anywhere">${esc(r.texto)}</p>
+    ${pie}
+  </div>`;
+}
+
+// --- Página completa ----------------------------------------------------------
+
+export async function renderReportes(
+  env: Env,
+  opts: { filtro?: string; enviado?: boolean } = {},
+): Promise<string> {
+  const repo = new ReportesRepo(new Db(env.DB));
+  const filtro: EstadoReporte | undefined =
+    opts.filtro === "abierto" || opts.filtro === "resuelto" ? opts.filtro : undefined;
+
+  const [lista, abiertos] = await Promise.all([repo.listar(filtro), repo.contarAbiertos()]);
+  const total = lista.length;
+
+  const pill = (href: string, texto: string, activo: boolean, color: string) =>
+    `<a href="${href}" class="chip" style="font-size:11px;letter-spacing:.05em;padding:5px 12px;white-space:nowrap;border:1px solid ${color};${
+      activo ? `background:${color};color:#1a1206;font-weight:700` : `color:${color}`
+    }">${texto}</a>`;
+
+  const cuerpoLista =
+    total === 0
+      ? `<div class="bg-panel border border-line" style="padding:40px 18px;text-align:center">
+           <i data-lucide="inbox" width="24" height="24" style="color:var(--dim);margin:0 auto 12px;display:block"></i>
+           <p style="font-size:13px;color:var(--muted);font-weight:600;margin:0">${filtro ? "Nada con este filtro" : "El buzón está vacío"}</p>
+           <p class="text-dim" style="font-size:11.5px;margin:6px auto 0;line-height:1.5;max-width:400px">
+             ${filtro ? "Prueba con otro filtro." : "Aquí van a llegar los avisos del equipo: una respuesta que salió mal, un dato equivocado, una idea para que el bot atienda mejor."}
+           </p>
+         </div>`
+      : lista.map(tarjeta).join("");
+
+  const aviso = opts.enviado
+    ? `<div style="border:1px solid var(--ok);background:rgba(127,183,126,.1);color:var(--ok);padding:10px 14px;font-size:12.5px;margin-bottom:14px">✓ Reporte enviado. Gracias — queda anotado aquí abajo.</div>`
+    : "";
+
+  const body = `
+    ${aviso}
+    <div class="grid grid-cols-1 lg:grid-cols-[380px_1fr] gap-4 items-start">
+      <div class="bg-panel border border-line" style="padding:16px 18px">
+        <div class="font-display text-cream" style="font-weight:700;font-size:15px">Reportar algo del bot</div>
+        <p class="text-dim" style="font-size:12px;line-height:1.55;margin:6px 0 14px">
+          ¿El bot contestó algo raro, dio un dato equivocado o se le puede mejorar algo?
+          Escríbelo aquí y lo revisamos. Si es de un chat en concreto, es mejor usar el
+          botón <b class="text-muted">⚑ Reportar</b> que está arriba de esa conversación.
+        </p>
+        ${formularioReporte({})}
+      </div>
+
+      <div style="min-width:0">
+        <div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:14px">
+          ${pill("/admin/reportes", `Todos · ${total}`, !filtro, "var(--accent)")}
+          ${pill("/admin/reportes?estado=abierto", `Pendientes · ${abiertos}`, filtro === "abierto", "var(--bad)")}
+          ${pill("/admin/reportes?estado=resuelto", "Resueltos", filtro === "resuelto", "var(--ok)")}
+        </div>
+        ${cuerpoLista}
+      </div>
+    </div>
+    ${RECORDAR_NOMBRE}`;
+
+  return layout({ title: "Buzón", activeTab: "reportes", body, env });
+}

--- a/src/db/reportes.ts
+++ b/src/db/reportes.ts
@@ -1,0 +1,113 @@
+/**
+ * BUZÓN DE REPORTES DEL EQUIPO (sale de atender clientes con el panel abierto todo el día).
+ *
+ * Lo que escriben las personas cuando el bot responde mal o se les ocurre una
+ * mejora. No confundir con:
+ *   · `tickets` — los abre el BOT cuando necesita a un humano.
+ *   · `suggestions` (pestaña Mejoras) — las propone la IA.
+ *
+ * Ver el comentario de la tabla en schema.sql.
+ */
+import { Db } from "./client";
+
+export type TipoReporte = "error" | "sugerencia";
+export type EstadoReporte = "abierto" | "resuelto";
+
+export interface Reporte {
+  id: string;
+  tipo: TipoReporte;
+  texto: string;
+  reportado_por: string | null;
+  conversation_id: string | null;
+  estado: EstadoReporte;
+  respuesta: string | null;
+  created_at: number;
+  resuelto_at: number | null;
+}
+
+export interface NuevoReporte {
+  tipo: TipoReporte;
+  texto: string;
+  reportadoPor?: string | null;
+  conversationId?: string | null;
+}
+
+/** Lo que se guarda de un texto libre: recortado y con tope, nunca vacío. */
+function limpiar(valor: string | null | undefined, tope: number): string {
+  return (valor ?? "").trim().slice(0, tope);
+}
+
+export class ReportesRepo {
+  constructor(private readonly db: Db) {}
+
+  /** Devuelve el id del reporte creado. `texto` vacío no llega hasta aquí. */
+  async crear(input: NuevoReporte): Promise<string> {
+    const id = crypto.randomUUID();
+    await this.db.run(
+      `INSERT INTO reportes (id, tipo, texto, reportado_por, conversation_id, estado, created_at)
+       VALUES (?, ?, ?, ?, ?, 'abierto', ?)`,
+      [
+        id,
+        input.tipo === "sugerencia" ? "sugerencia" : "error",
+        limpiar(input.texto, 2000),
+        limpiar(input.reportadoPor, 60) || null,
+        input.conversationId || null,
+        Date.now(),
+      ],
+    );
+    return id;
+  }
+
+  async getById(id: string): Promise<Reporte | null> {
+    return this.db.first<Reporte>("SELECT * FROM reportes WHERE id = ?", [id]);
+  }
+
+  /**
+   * Sin filtro devuelve TODO, pero con los abiertos arriba: lo pendiente es lo
+   * que hay que mirar, y lo resuelto queda de historial debajo.
+   */
+  async listar(estado?: EstadoReporte): Promise<Reporte[]> {
+    if (estado) {
+      return this.db.all<Reporte>(
+        "SELECT * FROM reportes WHERE estado = ? ORDER BY created_at DESC LIMIT 200",
+        [estado],
+      );
+    }
+    return this.db.all<Reporte>(
+      `SELECT * FROM reportes
+       ORDER BY CASE estado WHEN 'abierto' THEN 0 ELSE 1 END, created_at DESC
+       LIMIT 200`,
+    );
+  }
+
+  /** Los de una conversación (para el contador del hilo). */
+  async listarDeConversacion(conversationId: string): Promise<Reporte[]> {
+    return this.db.all<Reporte>(
+      "SELECT * FROM reportes WHERE conversation_id = ? ORDER BY created_at DESC",
+      [conversationId],
+    );
+  }
+
+  async contarAbiertos(): Promise<number> {
+    const fila = await this.db.first<{ n: number }>(
+      "SELECT COUNT(*) as n FROM reportes WHERE estado = 'abierto'",
+    );
+    return fila?.n ?? 0;
+  }
+
+  /** `respuesta` es opcional: qué se hizo, para que quede escrito. */
+  async resolver(id: string, respuesta?: string | null): Promise<void> {
+    await this.db.run(
+      "UPDATE reportes SET estado = 'resuelto', respuesta = ?, resuelto_at = ? WHERE id = ?",
+      [limpiar(respuesta, 1000) || null, Date.now(), id],
+    );
+  }
+
+  /** Se equivocaron al resolverlo: vuelve a la lista de pendientes. */
+  async reabrir(id: string): Promise<void> {
+    await this.db.run(
+      "UPDATE reportes SET estado = 'abierto', resuelto_at = NULL WHERE id = ?",
+      [id],
+    );
+  }
+}

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -203,3 +203,17 @@ CREATE TABLE IF NOT EXISTS template_sends (
   UNIQUE (campaign_key, conversation_id)
 );
 CREATE INDEX IF NOT EXISTS idx_template_sends_time ON template_sends(sent_at);
+
+CREATE TABLE IF NOT EXISTS reportes (
+  id TEXT PRIMARY KEY,
+  tipo TEXT NOT NULL DEFAULT 'error',
+  texto TEXT NOT NULL,
+  reportado_por TEXT,
+  conversation_id TEXT,
+  estado TEXT NOT NULL DEFAULT 'abierto',
+  respuesta TEXT,
+  created_at INTEGER NOT NULL,
+  resuelto_at INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_reportes_estado ON reportes(estado, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_reportes_conv ON reportes(conversation_id);

--- a/test/admin/reportes.test.ts
+++ b/test/admin/reportes.test.ts
@@ -1,0 +1,154 @@
+/**
+ * BUZÓN DE REPORTES DEL EQUIPO.
+ *
+ * Quien atiende ve una respuesta mala del bot y la reporta ahí mismo. Lo que se
+ * cuida aquí:
+ *   · que se pueda reportar desde la pestaña y desde el hilo de un chat;
+ *   · que listar, resolver y reabrir funcionen;
+ *   · LA REGRESIÓN QUE IMPORTA: reportar desde una conversación NO puede
+ *     ponerle el 🔔 de "necesita humano" a ese chat. Ese 🔔 es de los tickets
+ *     que abre el BOT, y si el buzón lo enciende, la bandeja empieza a mentir.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { createTestMiniflare } from "../helpers/miniflareSetup";
+import { adminApp } from "../../src/admin/routes";
+import { Db } from "../../src/db/client";
+import { ConversationsRepo } from "../../src/db/conversations";
+import { ReportesRepo } from "../../src/db/reportes";
+import type { Env } from "../../src/env";
+
+const PASSWORD = "secret123";
+const b64 = (s: string) =>
+  typeof btoa === "function" ? btoa(s) : Buffer.from(s, "utf-8").toString("base64");
+const AUTH = { Authorization: `Basic ${b64(`admin:${PASSWORD}`)}` };
+const FORM = { ...AUTH, "Content-Type": "application/x-www-form-urlencoded" };
+const FORM_HTMX = { ...FORM, "HX-Request": "true" };
+
+let env: Env;
+let db: Db;
+let convs: ConversationsRepo;
+let reportes: ReportesRepo;
+
+beforeEach(async () => {
+  const mf = await createTestMiniflare();
+  const d1 = (await mf.getD1Database("DB")) as any;
+  env = {
+    DB: d1,
+    BOT_NAME: "TestBot",
+    BUSINESS_NAME: "Negocio de Prueba",
+    BOT_LANGUAGE: "es",
+    BOT_TIER: "pro",
+    DASHBOARD_PASSWORD: PASSWORD,
+  } as unknown as Env;
+  db = new Db(d1);
+  convs = new ConversationsRepo(db);
+  reportes = new ReportesRepo(db);
+});
+
+describe("el buzón", () => {
+  it("guarda un reporte desde la pestaña", async () => {
+    const res = await adminApp.request(
+      "/reportes",
+      {
+        method: "POST",
+        headers: FORM,
+        body: new URLSearchParams({ texto: "contestó mal el horario", reportado_por: "Ana" }),
+      },
+      env,
+    );
+    expect(res.status).toBe(302);
+    const lista = await reportes.listar();
+    expect(lista).toHaveLength(1);
+    expect(lista[0].texto).toBe("contestó mal el horario");
+    expect(lista[0].reportado_por).toBe("Ana");
+    expect(lista[0].estado).toBe("abierto");
+  });
+
+  it("ignora un reporte vacío", async () => {
+    await adminApp.request(
+      "/reportes",
+      { method: "POST", headers: FORM, body: new URLSearchParams({ texto: "   " }) },
+      env,
+    );
+    expect(await reportes.listar()).toHaveLength(0);
+  });
+
+  it("resolver y reabrir", async () => {
+    const id = await reportes.crear({ tipo: "error", texto: "algo falló" });
+    await adminApp.request(
+      `/reportes/${id}/resolver`,
+      { method: "POST", headers: FORM, body: new URLSearchParams({ respuesta: "ya está" }) },
+      env,
+    );
+    expect((await reportes.listar())[0].estado).toBe("resuelto");
+
+    await adminApp.request(`/reportes/${id}/reabrir`, { method: "POST", headers: FORM }, env);
+    expect((await reportes.listar())[0].estado).toBe("abierto");
+  });
+
+  it("la pestaña se abre y muestra lo reportado", async () => {
+    await reportes.crear({ tipo: "error", texto: "se inventó un precio" });
+    const html = await (await adminApp.request("/reportes", { headers: AUTH }, env)).text();
+    expect(html).toContain("se inventó un precio");
+  });
+});
+
+describe("reportar desde el chat", () => {
+  it("el hilo trae el botón ⚑ con el formulario y el chat enganchado", async () => {
+    const conv = await convs.getOrCreate("whatsapp", "51999888777", "Rosa");
+    const html = await (
+      await adminApp.request(
+        `/conversations/thread/${encodeURIComponent(conv.id)}`,
+        { headers: AUTH },
+        env,
+      )
+    ).text();
+    expect(html).toContain("⚑ Reportar");
+    expect(html).toContain('hx-post="/admin/reportes"');
+    // sin esto, el reporte no diría de qué conversación habla
+    expect(html).toContain(`name="conversation_id" value="${conv.id}"`);
+  });
+
+  it("desde el hilo responde un fragmento, sin sacarte del chat", async () => {
+    const conv = await convs.getOrCreate("whatsapp", "51999888777", "Rosa");
+    const res = await adminApp.request(
+      "/reportes",
+      {
+        method: "POST",
+        headers: FORM_HTMX,
+        body: new URLSearchParams({ texto: "respondió cualquier cosa", conversation_id: conv.id }),
+      },
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Reporte")).toBe("1");
+    const lista = await reportes.listar();
+    expect(lista[0].conversation_id).toBe(conv.id);
+  });
+
+  // LA REGRESIÓN QUE IMPORTA.
+  it("reportar NO le pone el 🔔 de «necesita humano» a la conversación", async () => {
+    const conv = await convs.getOrCreate("whatsapp", "51999888777", "Rosa");
+    await adminApp.request(
+      "/reportes",
+      {
+        method: "POST",
+        headers: FORM_HTMX,
+        body: new URLSearchParams({ texto: "mal", conversation_id: conv.id }),
+      },
+      env,
+    );
+    const tickets = await db.all<any>("SELECT * FROM tickets WHERE conversation_id = ?", [conv.id]);
+    expect(tickets).toHaveLength(0);
+
+    const hilo = await (
+      await adminApp.request(
+        `/conversations/thread/${encodeURIComponent(conv.id)}`,
+        { headers: AUTH },
+        env,
+      )
+    ).text();
+    expect(hilo).not.toContain("ticket abierto");
+  });
+});


### PR DESCRIPTION
## El problema

**El dueño no es el único que ve los errores del bot.** Quien atiende —una secretaria, un socio— ve una respuesta mala y hoy no tiene dónde dejarla: te escribe por interno, o se pierde.

## Qué añade

Una pestaña **Buzón** y, sobre todo, un botón **⚑ dentro de cada conversación** — que es el caso de uso real: ves la respuesta mala y la reportas **en el momento**, con el chat ya enganchado. Sin salir del hilo y sin tener que explicar de qué conversación hablabas.

Al dueño le llega el aviso por el mismo camino que los handoffs (`notifyOwner`: Telegram/correo), con el enlace directo al chat.

Se puede **filtrar por estado**, **resolver** con una respuesta y **reabrir**. El nombre de quien reporta se recuerda en su navegador para que no lo escriba cada vez.

## Dos decisiones que vale la pena explicar

**1. Tabla propia, no `tickets`.** Y hay una prueba dedicada solo a esa regresión.

`tickets` los abre el **BOT** cuando necesita a un humano, y marcan la conversación con el 🔔 de *"necesita humano"*. Si el buzón los reusara, la bandeja **empezaría a mentir**: verías chats marcados como "el bot pidió ayuda" que en realidad son alguien del equipo dejando una nota. Son dos cosas distintas y tienen que seguir siéndolo.

**2. El aviso va en segundo plano** (`waitUntil`). Si Telegram tarda o falla, quien reportó no se queda esperando — y el reporte **ya está guardado** antes de intentar avisar.

## Pruebas

`npx vitest run --no-file-parallelism` → **444 en verde**, incluidas 7 nuevas: guardar desde la pestaña y desde el hilo, ignorar un reporte vacío, resolver y reabrir, que el chat viaje enganchado, y la regresión del 🔔.

## Archivos

| Archivo | Qué es |
|---|---|
| `src/db/reportes.ts` | nuevo — el repo |
| `src/admin/views/reportes.ts` | nuevo — la pestaña + el formulario reutilizable |
| `src/db/schema.sql` | tabla `reportes` + 2 índices |
| `src/admin/routes.ts` | GET /reportes, POST /reportes, resolver, reabrir |
| `src/admin/views/layout.ts` | 1 línea: el Buzón en el menú |
| `src/admin/views/conversations.ts` | el botón ⚑ en el hilo |
| `test/admin/reportes.test.ts` | nuevo |
