### PR TITLE
feat(panel): la barra del chat, con cada cosa en su sitio y en una sola fila

### DIFF
--- a/src/admin/views/conversations.ts
+++ b/src/admin/views/conversations.ts
@@ -209,6 +209,79 @@ export async function renderInboxList(env: Env, p: InboxParams): Promise<string>
 
 // --- Right pane: live thread (header + messages, polled) ----------------------
 
+
+/**
+ * LA BARRA DE ARRIBA DEL CHAT.
+ *
+ * Tres problemas que resuelve:
+ *
+ *  1. Los botones se corrían de lugar según cuántas etiquetas tuviera ese chat
+ *     (ticket abierto, pausado, la emoción del cliente). Abres dos
+ *     conversaciones seguidas y "Pausar" no está en el mismo sitio.
+ *  2. La barra ocupaba DOS filas y se comía alto de pantalla en cada chat.
+ *  3. Forzarla a una fila rompía el panel en pantallas medianas: el chat entero
+ *     se salía por la derecha, con el botón cortado por la mitad.
+ *
+ * Ahora son tres bloques fijos —QUIÉN · MARCAS · ACCIONES, las acciones siempre
+ * pegadas a la derecha y siempre en el mismo orden— y la fila única se PIDE,
+ * solo si el chat mide lo suficiente.
+ *
+ * ✱ LO CONTRAINTUITIVO: acortar el TEXTO de los botones no ahorra alto. Medido
+ *   en el navegador: 82 px antes y 82 px después. Lo que ahorra es que quepa en
+ *   UNA fila — ahí baja a 47 px.
+ *
+ * ✱ Se mide el ancho del CHAT (container query), no el de la ventana: entre el
+ *   menú y la lista se van ~570 px, así que una pantalla "grande" puede dejar
+ *   un chat estrecho. Con una media query normal esto falla justo en las
+ *   pantallas de escritorio medianas.
+ *
+ * ✱ El umbral se MIDE, no se pone a ojo: se le da width:max-content a los tres
+ *   bloques y se lee lo que ocupan de verdad.
+ *
+ * ✱ El bloque del nombre lleva min-width: sin él, con varias etiquetas a la vez
+ *   se recortaba hasta DESAPARECER y quedaban solo el avatar y el número.
+ */
+const ESTILO_CABECERA = `<style>
+  .hilo-barra{display:flex;flex-wrap:wrap;align-items:center;gap:8px 10px;
+    padding:11px 16px;min-width:0;max-width:100%;
+    border-bottom:1px solid var(--line);background:var(--panel)}
+  .hilo-quien{display:flex;align-items:center;gap:8px;min-width:0;flex:1 1 140px;overflow:hidden}
+  .hilo-marcas{display:flex;align-items:center;gap:6px;flex:none}
+  .hilo-acciones{display:flex;align-items:center;gap:8px;flex-wrap:wrap;
+    width:100%;justify-content:flex-end}
+
+  /* La cadena ENTERA necesita min-width:0 para poder encogerse: basta que un
+     eslabón lo olvide para que un nombre largo lo empuje todo fuera. */
+  .hilo-quien > span:first-child{
+    display:block;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+
+  /* Ninguna etiqueta parte en dos renglones: si una se parte, la barra crece y
+     el chat de al lado se ve distinto. */
+  .hilo-barra span, .hilo-barra a, .hilo-barra button, .hilo-barra summary{white-space:nowrap}
+
+  /* Mientras la barra está en dos filas, un cuadro desplegable se adueña de su
+     fila en vez de flotar: anclado a la derecha se salía de la pantalla en el
+     teléfono. Lleva !important porque los elementos traen position/width
+     escritos en su propio atributo style. */
+  .hilo-acciones details[open]{width:100%;position:static}
+  .hilo-acciones details[open] > div{
+    position:static !important;width:auto !important;max-width:none !important;box-shadow:none}
+
+  @container (min-width: 620px) {
+    .hilo-barra{flex-wrap:nowrap}
+    .hilo-quien{flex:0 1 auto;min-width:150px}
+    .hilo-acciones{width:auto;flex-wrap:nowrap;margin-left:auto}
+    .hilo-acciones details[open]{width:auto;position:relative}
+    .hilo-acciones details[open] > div{
+      position:absolute !important;max-width:78vw !important;
+      box-shadow:6px 6px 0 rgba(0,0,0,.4)}
+  }
+
+  @media (max-width:767px){
+    .hilo-barra{padding:8px 10px;gap:6px 8px}
+  }
+</style>`;
+
 export async function renderThreadLive(env: Env, convId: string): Promise<string> {
   const db = new Db(env.DB);
   const conv = await db.first<any>("SELECT * FROM conversations WHERE id = ?", [convId]);
@@ -253,18 +326,25 @@ export async function renderThreadLive(env: Env, convId: string): Promise<string
     </details>`
     : `
     <button hx-post="/admin/conversations/${encodeURIComponent(convId)}/pause" hx-target="#thread-live" hx-swap="innerHTML"
-            class="chip" style="margin-left:auto;font-size:11px;color:var(--muted);background:var(--panel2);border:1px solid var(--linelit);padding:6px 11px;cursor:pointer">
+            class="chip" style="font-size:11px;color:var(--muted);background:var(--panel2);border:1px solid var(--linelit);padding:6px 11px;cursor:pointer">
       ⏸ Pausar bot aquí
     </button>`;
 
   const header = `
-  <div style="display:flex;flex-wrap:wrap;align-items:center;gap:8px;padding:12px 16px;border-bottom:1px solid var(--line);background:var(--panel)">
-    <span style="font-family:'Space Grotesk';font-weight:600;font-size:14px;color:var(--cream)">${escapeHtml(conv.display_name ?? conv.channel_user_id)}</span>
-    <span style="${smallPill("var(--info)")}">${escapeHtml(channelLabel(conv.channel))}</span>
-    ${statusPill}
-    ${sentBadge}
-    ${openTicket > 0 ? `<span style="${statusBadge("var(--accent-2)")}">🔔 ticket abierto</span>` : ""}
-    ${controls}
+  ${ESTILO_CABECERA}
+  <div class="hilo-barra">
+    <div class="hilo-quien">
+      <span style="font-family:'Space Grotesk';font-weight:600;font-size:14px;color:var(--cream)">${escapeHtml(conv.display_name ?? conv.channel_user_id)}</span>
+    </div>
+    <div class="hilo-marcas">
+      <span style="${smallPill("var(--info)")}">${escapeHtml(channelLabel(conv.channel))}</span>
+      ${openTicket > 0 ? `<span style="${statusBadge("var(--accent-2)")}">🔔</span>` : ""}
+      ${sentBadge}
+      ${statusPill}
+    </div>
+    <div class="hilo-acciones">
+      ${controls}
+    </div>
   </div>`;
 
   // Messages, DESC in the DOM + column-reverse = pinned to bottom.
@@ -292,7 +372,7 @@ export async function renderThreadLive(env: Env, convId: string): Promise<string
       if (m.role === "user") {
         return `
         <div style="display:flex;flex-direction:column;align-items:flex-start;gap:4px;max-width:78%">
-          <div style="background:var(--panel2);border:1px solid var(--line);padding:9px 13px;font-size:12.5px;line-height:1.5;white-space:pre-wrap;color:var(--cream)">${escapeHtml(m.content)}</div>
+          <div style="background:var(--panel2);border:1px solid var(--line);padding:9px 13px;font-size:12.5px;line-height:1.5;white-space:pre-wrap;overflow-wrap:anywhere;min-width:0;color:var(--cream)">${escapeHtml(m.content)}</div>
           <span style="font-size:9.5px;color:var(--dim)">${time}</span>
         </div>`;
       }
@@ -308,7 +388,7 @@ export async function renderThreadLive(env: Env, convId: string): Promise<string
       return `
       <div style="display:flex;flex-direction:column;align-items:flex-end;gap:4px;max-width:78%;margin-left:auto">
         ${chips}
-        <div style="${bubbleBg};padding:9px 13px;font-size:12.5px;line-height:1.5;white-space:pre-wrap;color:var(--cream)">${escapeHtml(m.content)}</div>
+        <div style="${bubbleBg};padding:9px 13px;font-size:12.5px;line-height:1.5;white-space:pre-wrap;overflow-wrap:anywhere;min-width:0;color:var(--cream)">${escapeHtml(m.content)}</div>
         <span style="font-size:9.5px;color:var(--dim)">${meta}</span>
       </div>`;
     })
@@ -401,7 +481,7 @@ export async function renderInbox(env: Env, p: InboxParams): Promise<string> {
   if (p.selectedId) {
     const thread = await renderThreadLive(env, p.selectedId);
     rightPane = `
-      <div id="thread-live" class="flex flex-col flex-1 min-h-0"
+      <div id="thread-live" class="flex flex-col flex-1 min-h-0" style="container-type:inline-size;min-width:0"
            hx-get="/admin/conversations/thread/${encodeURIComponent(p.selectedId)}"
            hx-trigger="every 5s" hx-swap="innerHTML">
         ${thread}

--- a/test/admin/barra-del-chat.test.ts
+++ b/test/admin/barra-del-chat.test.ts
@@ -1,0 +1,100 @@
+/**
+ * LA BARRA DE ARRIBA DEL CHAT.
+ *
+ * Lo que se cuida: que cada cosa esté SIEMPRE en el mismo sitio (antes los
+ * botones se corrían según cuántas etiquetas tuviera ese chat) y que la fila
+ * única se pida por el ancho REAL del chat, no por el de la ventana.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { createTestMiniflare } from "../helpers/miniflareSetup";
+import { adminApp } from "../../src/admin/routes";
+import { Db } from "../../src/db/client";
+import { ConversationsRepo } from "../../src/db/conversations";
+import { MessagesRepo } from "../../src/db/messages";
+import type { Env } from "../../src/env";
+
+const PASSWORD = "secret123";
+const b64 = (s: string) =>
+  typeof btoa === "function" ? btoa(s) : Buffer.from(s, "utf-8").toString("base64");
+const AUTH = { Authorization: `Basic ${b64(`admin:${PASSWORD}`)}` };
+
+let env: Env;
+let db: Db;
+let convs: ConversationsRepo;
+let msgs: MessagesRepo;
+
+beforeEach(async () => {
+  const mf = await createTestMiniflare();
+  const d1 = (await mf.getD1Database("DB")) as any;
+  env = {
+    DB: d1,
+    BOT_NAME: "TestBot",
+    BUSINESS_NAME: "Negocio de Prueba",
+    BOT_LANGUAGE: "es",
+    BOT_TIER: "pro",
+    DASHBOARD_PASSWORD: PASSWORD,
+  } as unknown as Env;
+  db = new Db(d1);
+  convs = new ConversationsRepo(db);
+  msgs = new MessagesRepo(db);
+});
+
+const hilo = async (id: string) =>
+  (await adminApp.request(`/conversations/thread/${encodeURIComponent(id)}`, { headers: AUTH }, env)).text();
+
+const bloques = (html: string) => ({
+  quien: html.indexOf('class="hilo-quien"'),
+  marcas: html.indexOf('class="hilo-marcas"'),
+  acciones: html.indexOf('class="hilo-acciones"'),
+});
+
+describe("los tres bloques", () => {
+  it("van siempre en el mismo orden, haya o no etiquetas", async () => {
+    const pelado = await convs.getOrCreate("whatsapp", "51900000001", "Sin nada");
+    const cargado = await convs.getOrCreate("whatsapp", "51900000002", "Con todo");
+    await db.run(
+      "INSERT INTO tickets (id, conversation_id, category, summary, transcript, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+      ["t-1", cargado.id, "duda", "necesita humano", "—", Date.now()],
+    );
+    await convs.setPausedUntil(cargado.id, Date.now() + 60_000);
+
+    for (const conv of [pelado, cargado]) {
+      const b = bloques(await hilo(conv.id));
+      expect(b.quien).toBeGreaterThan(-1);
+      expect(b.marcas).toBeGreaterThan(b.quien);
+      expect(b.acciones).toBeGreaterThan(b.marcas);
+    }
+  });
+
+  it("la forma de partida son DOS filas, que siempre caben", async () => {
+    const conv = await convs.getOrCreate("whatsapp", "51900000003", "Cliente");
+    expect(await hilo(conv.id)).toContain("flex-wrap:wrap");
+  });
+
+  it("la fila única se pide por el ancho del CHAT, no el de la ventana", async () => {
+    const conv = await convs.getOrCreate("whatsapp", "51900000004", "Cliente");
+    const html = await hilo(conv.id);
+    expect(html).toContain("@container (min-width: 620px)");
+    // y el nombre nunca puede encogerse hasta desaparecer
+    expect(html).toContain("min-width:150px");
+  });
+
+  it("el chat declara container-type para que el container query mida", async () => {
+    const conv = await convs.getOrCreate("whatsapp", "51900000005", "Cliente");
+    const pagina = await (
+      await adminApp.request(`/conversations?c=${encodeURIComponent(conv.id)}`, { headers: AUTH }, env)
+    ).text();
+    expect(pagina).toContain("container-type:inline-size");
+  });
+});
+
+describe("una URL larga no empuja el panel", () => {
+  it("las burbujas parten las palabras que no caben", async () => {
+    const conv = await convs.getOrCreate("whatsapp", "51900000006", "Cliente");
+    await msgs.append(conv.id, "user", "mira esto https://ejemplo.com/" + "x".repeat(200));
+    const html = await hilo(conv.id);
+    expect(html).toContain("overflow-wrap:anywhere");
+    expect(html).toContain("min-width:0");
+  });
+});


### PR DESCRIPTION
## Tres problemas

1. **Los botones se corrían de lugar** según cuántas etiquetas tuviera ese chat (ticket abierto, pausado, la emoción del cliente). Abres dos conversaciones seguidas y "Pausar" no está en el mismo sitio.
2. **La barra ocupaba dos filas** y se comía alto de pantalla en cada chat.
3. **Forzarla a una fila rompía el panel** en pantallas medianas: el chat entero se salía por la derecha, con el botón cortado por la mitad.

Ahora son **tres bloques fijos** —QUIÉN · MARCAS · ACCIONES, las acciones siempre pegadas a la derecha— y la fila única se **pide**, solo si el chat mide lo suficiente.

## Lo contraintuitivo (y el aporte de verdad)

**Acortar el texto de los botones NO ahorra alto.** Lo medí en el navegador: **82 px antes y 82 px después**. Lo que ahorra es que quepa en **una** fila — ahí baja a **47 px**.

Si tu objetivo es ganar alto de pantalla, el texto de los botones es lo de menos.

## Detalles que costaron

- **Se mide el ancho del CHAT (container query), no el de la ventana.** Entre el menú y la lista se van ~570 px: una pantalla "grande" puede dejar un chat estrecho, y con una media query normal esto falla justo en las pantallas de escritorio medianas. Si el navegador no entiende container queries, se queda en dos filas — la forma segura.
- **El umbral se mide, no se pone a ojo**: se le da `width:max-content` a los tres bloques y se lee lo que ocupan de verdad.
- **El bloque del nombre lleva `min-width`.** Sin él, con varias etiquetas a la vez se recortaba hasta **desaparecer** y en la barra quedaban solo el avatar y el número: el chat dejaba de decirte con quién hablas.
- **En dos filas, un cuadro desplegable no puede flotar**: anclado a la derecha se salía de la pantalla en el teléfono. Lleva `!important` porque los elementos traen `position`/`width` escritos en su propio atributo `style` — y eso le gana a la media query.
- El ticket queda en **🔔 a secas**: el texto "ticket abierto" hacía crecer la barra sin aportar nada.

## De paso

Una **URL larga** (sin espacios) empujaba **todo** el panel hacia la derecha. `pre-wrap` respeta los saltos pero **no** parte palabras largas, y sin `min-width:0` un hijo flex no puede encogerse por debajo de su contenido.

## Pruebas

`npx vitest run --no-file-parallelism` → **442 en verde**, incluidas 5 nuevas: que los tres bloques vayan en el mismo orden con y sin etiquetas, que la forma de partida sean dos filas, que el umbral sea por container query, y que las burbujas partan una URL larga.
