### PR TITLE
feat(panel): cada chat se ve como la app de la que viene

### DIFF
--- a/src/admin/views/conversations.ts
+++ b/src/admin/views/conversations.ts
@@ -18,6 +18,7 @@ import { SENTIMENT_BADGE } from "./insights";
 import { costOfUsage, type ModelId } from "../../pricing";
 import { channelLabel } from "../../channels/labels";
 import { layout } from "./layout";
+import { temaDelCanal, estiloDelTema, colorDeMarca } from "./temaCanal";
 
 /** Tiempo relativo corto en español (ej. "hace 5 min", "hace 2 h", "hace 3 d"). */
 function ago(ms: number | null | undefined): string {
@@ -103,9 +104,15 @@ function initialsOf(label: string): string {
 }
 
 /** WhatsApp gets info-blue, every other channel gets accent-2 amber — mirrors the mockup's WA/other split. */
+/**
+ * Cada etiqueta con el color de SU red: el verde de WhatsApp, el azul de
+ * Telegram. De un vistazo se ve por dónde escribió cada persona, sin leer.
+ * Los tonos salen de temaCanal.ts, los mismos que visten el hilo al abrirlo.
+ */
 function channelColor(channel: string): string {
-  return channel === "twilio" || channel === "whatsapp" ? "var(--info)" : "var(--accent-2)";
+  return colorDeMarca(channel);
 }
+
 
 interface InboxParams {
   search?: string;
@@ -214,6 +221,11 @@ export async function renderThreadLive(env: Env, convId: string): Promise<string
   const conv = await db.first<any>("SELECT * FROM conversations WHERE id = ?", [convId]);
   if (!conv) return `<div style="padding:24px;font-size:12.5px;color:var(--dim)">Conversación no encontrada.</div>`;
 
+  // Cada chat se viste como la app de la que viene. Ver temaCanal.ts: el alcance
+  // es DELIBERADO — solo el hilo. La lista, los filtros y las tarjetas conservan
+  // la identidad del panel, porque son la herramienta de trabajo, no el chat.
+  const tema = temaDelCanal(conv.channel);
+
   const insight = await new InsightsRepo(db).getByConversation(convId);
   const msgs = await db.all<any>(
     "SELECT * FROM messages WHERE conversation_id = ? ORDER BY created_at DESC LIMIT 100",
@@ -258,7 +270,7 @@ export async function renderThreadLive(env: Env, convId: string): Promise<string
     </button>`;
 
   const header = `
-  <div style="display:flex;flex-wrap:wrap;align-items:center;gap:8px;padding:12px 16px;border-bottom:1px solid var(--line);background:var(--panel)">
+  <div style="display:flex;flex-wrap:wrap;align-items:center;gap:8px;padding:12px 16px;border-bottom:1px solid rgba(0,0,0,.10);background:var(--ch-barra)">
     <span style="font-family:'Space Grotesk';font-weight:600;font-size:14px;color:var(--cream)">${escapeHtml(conv.display_name ?? conv.channel_user_id)}</span>
     <span style="${smallPill("var(--info)")}">${escapeHtml(channelLabel(conv.channel))}</span>
     ${statusPill}
@@ -292,8 +304,8 @@ export async function renderThreadLive(env: Env, convId: string): Promise<string
       if (m.role === "user") {
         return `
         <div style="display:flex;flex-direction:column;align-items:flex-start;gap:4px;max-width:78%">
-          <div style="background:var(--panel2);border:1px solid var(--line);padding:9px 13px;font-size:12.5px;line-height:1.5;white-space:pre-wrap;color:var(--cream)">${escapeHtml(m.content)}</div>
-          <span style="font-size:9.5px;color:var(--dim)">${time}</span>
+          <div style="background:var(--ch-ajena);border-radius:var(--ch-radio);padding:9px 13px;font-size:14.5px;line-height:1.45;white-space:pre-wrap;overflow-wrap:anywhere;color:var(--ch-texto)">${escapeHtml(m.content)}</div>
+          <span style="font-size:9.5px;color:var(--ch-suave)">${time}</span>
         </div>`;
       }
 
@@ -302,31 +314,35 @@ export async function renderThreadLive(env: Env, convId: string): Promise<string
       const meta = isOwner
         ? `Tú · ${time}`
         : [m.model_used ? modelShort(m.model_used) : null, cost || null, time].filter(Boolean).join(" · ");
+      // Lo que sale de nuestro lado (bot o equipo) va en la burbuja "propia" de
+      // la app; el matiz del equipo se marca con un borde, no con otro color.
       const bubbleBg = isOwner
-        ? "background:rgba(245,166,35,.1);border:1px solid rgba(245,166,35,.4)"
-        : "background:var(--accent-soft);border:1px solid var(--linelit)";
+        ? "background:var(--ch-propia);border:1px solid var(--ch-marca)"
+        : "background:var(--ch-propia)";
       return `
       <div style="display:flex;flex-direction:column;align-items:flex-end;gap:4px;max-width:78%;margin-left:auto">
         ${chips}
-        <div style="${bubbleBg};padding:9px 13px;font-size:12.5px;line-height:1.5;white-space:pre-wrap;color:var(--cream)">${escapeHtml(m.content)}</div>
-        <span style="font-size:9.5px;color:var(--dim)">${meta}</span>
+        <div style="${bubbleBg};border-radius:var(--ch-radio);padding:9px 13px;font-size:14.5px;line-height:1.45;white-space:pre-wrap;overflow-wrap:anywhere;color:var(--ch-texto)">${escapeHtml(m.content)}</div>
+        <span style="font-size:9.5px;color:var(--ch-suave)">${meta}</span>
       </div>`;
     })
     .join("");
 
   return `
+  <div style="${estiloDelTema(tema)};display:flex;flex-direction:column;flex:1;min-height:0">
   ${header}
-  <div style="flex:1;min-height:0;overflow-y:auto;display:flex;flex-direction:column-reverse;gap:12px;padding:16px;background:var(--bg)">
-    ${bubbles || `<div style="text-align:center;font-size:12.5px;color:var(--dim);padding:32px 0">Sin mensajes.</div>`}
+  <div style="flex:1;min-height:0;overflow-y:auto;display:flex;flex-direction:column-reverse;gap:12px;padding:16px;background:var(--ch-fondo)">
+    ${bubbles || `<div style="text-align:center;font-size:12.5px;color:var(--ch-suave);padding:32px 0">Sin mensajes.</div>`}
+  </div>
   </div>`;
 }
 
 // --- Composer (static per selection — NOT inside the polled fragment) ---------
 
-function renderComposer(convId: string): string {
+function renderComposer(convId: string, tema = temaDelCanal(null)): string {
   const id = encodeURIComponent(convId);
   return `
-  <div style="border-top:1px solid var(--line);background:var(--panel);padding:12px;display:flex;flex-direction:column;gap:8px">
+  <div style="${estiloDelTema(tema)};border-top:1px solid rgba(0,0,0,.10);background:var(--ch-barra);padding:12px;display:flex;flex-direction:column;gap:8px">
     <div id="suggestion-box"></div>
     <form hx-post="/admin/conversations/${id}/reply" hx-target="#send-status" hx-swap="innerHTML"
           hx-on::after-request="if(event.detail.xhr.getResponseHeader('X-Sent')==='1')this.reset()"
@@ -397,6 +413,12 @@ export async function renderInbox(env: Env, p: InboxParams): Promise<string> {
     ...(p.selectedId ? { c: p.selectedId } : {}),
   }).toString()}`;
 
+  // El canal de la conversación abierta: el cajón de respuesta se viste igual
+  // que el hilo, si no el corte entre uno y otro se nota.
+  const canalSeleccionado = p.selectedId
+    ? ((await db.first<{ channel: string }>("SELECT channel FROM conversations WHERE id = ?", [p.selectedId]))?.channel ?? null)
+    : null;
+
   let rightPane: string;
   if (p.selectedId) {
     const thread = await renderThreadLive(env, p.selectedId);
@@ -406,7 +428,7 @@ export async function renderInbox(env: Env, p: InboxParams): Promise<string> {
            hx-trigger="every 5s" hx-swap="innerHTML">
         ${thread}
       </div>
-      ${renderComposer(p.selectedId)}`;
+      ${renderComposer(p.selectedId, temaDelCanal(canalSeleccionado))}`;
   } else {
     rightPane = `
       <div class="flex-1 flex items-center justify-center" style="font-size:12.5px;color:var(--dim);background:var(--bg)">

--- a/src/admin/views/temaCanal.ts
+++ b/src/admin/views/temaCanal.ts
@@ -1,0 +1,178 @@
+// Cada chat se ve como la app de la que viene.
+//
+// POR QUÉ (sale de atender clientes con el panel abierto todo el día): cuando se conecte WhatsApp, el número
+// deja de funcionar en la app normal y el equipo tiene que atender desde este
+// panel. Sus secretarias llevan años en WhatsApp; si el chat se ve como una
+// terminal, el cambio se siente brusco y se cometen errores. Que cada
+// conversación se parezca a su app de origen (colores, burbujas, tipografía)
+// hace que el traslado sea casi invisible.
+//
+// Alcance deliberado: SOLO el hilo de conversación. El resto del panel —la
+// lista, los filtros, las tarjetas— conserva su identidad, porque es la
+// herramienta de trabajo, no el chat.
+//
+// Sobre las tipografías: WhatsApp, Telegram e Instagram usan la fuente del
+// SISTEMA en Android/iOS (Roboto y San Francisco). Aquí se pide exactamente esa
+// pila, que es lo que hace que "se sienta" como la app. No se descarga ninguna
+// fuente externa: sería más lento, y las propias de esas marcas no son libres.
+
+export type CanalTema = {
+  /** Nombre de la app, para el encabezado del hilo. */
+  nombre: string;
+  /** Fondo del área de mensajes. */
+  fondo: string;
+  /** Fondo de la barra superior del chat y del cajón de respuesta. */
+  barra: string;
+  /** Burbuja de lo que enviamos nosotros (bot o equipo). */
+  propia: string;
+  /** Burbuja de lo que escribe el cliente. */
+  ajena: string;
+  /** Color del texto dentro de las burbujas. */
+  texto: string;
+  /** Color secundario (hora, metadatos). */
+  suave: string;
+  /** Color de marca, para detalles. */
+  marca: string;
+  /** Pila tipográfica de la app. */
+  fuente: string;
+  /** Radio de las esquinas de la burbuja. */
+  radio: string;
+};
+
+/** La fuente que usan de verdad estas apps en el teléfono: la del sistema. */
+// ⚠️ COMILLAS SIMPLES a propósito. Esta cadena termina dentro de un atributo
+// HTML `style="…"`; con comillas dobles el navegador corta el atributo ahí
+// mismo y la fuente NUNCA se aplica (pasó en la primera versión, 28/07/2026).
+const FUENTE_SISTEMA =
+  "-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif";
+
+/** Tema del panel (el de siempre) — para canales sin app propia. */
+const GENERICO: CanalTema = {
+  nombre: "Chat",
+  fondo: "var(--bg)",
+  barra: "var(--panel)",
+  propia: "var(--accent-soft)",
+  ajena: "var(--panel2)",
+  texto: "var(--cream)",
+  suave: "var(--dim)",
+  marca: "var(--accent)",
+  fuente: "inherit",
+  radio: "0",
+};
+
+// Los valores salen de las apps en MODO OSCURO, que es el modo del panel.
+const TEMAS: Record<string, CanalTema> = {
+  whatsapp: {
+    nombre: "WhatsApp",
+    fondo: "#0b141a",
+    barra: "#1f2c34",
+    propia: "#005c4b", // el verde de los mensajes propios
+    ajena: "#202c33",
+    texto: "#e9edef",
+    suave: "#8696a0",
+    marca: "#00a884",
+    fuente: FUENTE_SISTEMA,
+    radio: "7px",
+  },
+  telegram: {
+    nombre: "Telegram",
+    fondo: "#0e1621",
+    barra: "#17212b",
+    propia: "#2b5278", // el azul de los mensajes propios
+    ajena: "#182533",
+    texto: "#ffffff",
+    suave: "#7d8e98",
+    marca: "#5288c1",
+    fuente: FUENTE_SISTEMA,
+    radio: "12px",
+  },
+  instagram: {
+    nombre: "Instagram",
+    fondo: "#000000",
+    barra: "#121212",
+    propia: "#3797f0", // el azul de los DM propios
+    ajena: "#262626",
+    texto: "#fafafa",
+    suave: "#a8a8a8",
+    marca: "#e1306c",
+    fuente: FUENTE_SISTEMA,
+    radio: "18px", // los DM de Instagram son muy redondeados
+  },
+  messenger: {
+    nombre: "Messenger",
+    fondo: "#000000",
+    barra: "#1c1e21",
+    propia: "#0084ff",
+    ajena: "#303030",
+    texto: "#e4e6eb",
+    suave: "#b0b3b8",
+    marca: "#0084ff",
+    fuente: FUENTE_SISTEMA,
+    radio: "18px",
+  },
+};
+
+/** Twilio, ManyChat, Kapso y YCloud son transportes, no apps: se muestran como
+ *  lo que llevan. Para el equipo lo que importa es por dónde escribió el
+ *  cliente, no qué proveedor usamos por dentro. */
+const EQUIVALENCIAS: Record<string, string> = {
+  twilio: "whatsapp",
+  kapso: "whatsapp",
+  ycloud: "whatsapp",
+  meta: "messenger",
+  manychat: "instagram", // ManyChat entra por los DM de Instagram
+};
+
+/**
+ * El tema que corresponde a un canal. Nunca falla: cae al del panel.
+ *
+ * `plataformaReal` es para ZERNIO, que es un puente multiplataforma: una misma
+ * conexión trae WhatsApp, Instagram o Telegram. Sin esto, todos sus chats se
+ * veían con el tema genérico de terminal — que es justo lo que este módulo
+ * existe para evitar (se notó con el primer WhatsApp que
+ * entró por Zernio: "aún parece un chat que no es de WhatsApp").
+ */
+export function temaDelCanal(
+  canal: string | null | undefined,
+  plataformaReal?: string | null,
+): CanalTema {
+  const bruto = (canal ?? "").trim().toLowerCase();
+  const id =
+    bruto === "zernio" && plataformaReal ? plataformaReal.trim().toLowerCase() : bruto;
+  return TEMAS[id] ?? TEMAS[EQUIVALENCIAS[id] ?? ""] ?? GENERICO;
+}
+
+/**
+ * El COLOR DE MARCA del canal, para la etiqueta de la lista de conversaciones:
+ * el verde de WhatsApp, el azul de Telegram, el rosa de Instagram… Antes todas
+ * las etiquetas eran del mismo par de colores del panel y no se distinguía de
+ * un vistazo por dónde escribió cada persona (sale de atender clientes con el panel abierto todo el día).
+ *
+ * Los tonos son los mismos que ya usa el tema del hilo, así que la etiqueta y
+ * el chat que abre debajo hablan el mismo idioma visual.
+ */
+export function colorDeMarca(
+  canal: string | null | undefined,
+  plataformaReal?: string | null,
+): string {
+  const t = temaDelCanal(canal, plataformaReal);
+  return t === GENERICO ? "var(--accent-2)" : t.marca;
+}
+
+/**
+ * Variables CSS del tema, para ponerlas en el `style` del contenedor del hilo.
+ * Todo lo de dentro (barra, burbujas, cajón) se dibuja con estas variables.
+ */
+export function estiloDelTema(t: CanalTema): string {
+  return [
+    `--ch-fondo:${t.fondo}`,
+    `--ch-barra:${t.barra}`,
+    `--ch-propia:${t.propia}`,
+    `--ch-ajena:${t.ajena}`,
+    `--ch-texto:${t.texto}`,
+    `--ch-suave:${t.suave}`,
+    `--ch-marca:${t.marca}`,
+    `--ch-radio:${t.radio}`,
+    `font-family:${t.fuente}`,
+  ].join(";");
+}

--- a/test/admin/tema-canal.test.ts
+++ b/test/admin/tema-canal.test.ts
@@ -1,0 +1,103 @@
+/**
+ * CADA CHAT SE VE COMO LA APP DE LA QUE VIENE.
+ *
+ * No es decoración. Cuando conectas el número oficial de WhatsApp, deja de
+ * funcionar en la app normal y tu equipo tiene que atender desde el panel. Si
+ * ahí se ve como una terminal, el cambio se siente brusco y se cometen errores.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { createTestMiniflare } from "../helpers/miniflareSetup";
+import { adminApp } from "../../src/admin/routes";
+import { Db } from "../../src/db/client";
+import { ConversationsRepo } from "../../src/db/conversations";
+import { temaDelCanal, estiloDelTema, colorDeMarca } from "../../src/admin/views/temaCanal";
+import type { Env } from "../../src/env";
+
+const PASSWORD = "secret123";
+const b64 = (s: string) =>
+  typeof btoa === "function" ? btoa(s) : Buffer.from(s, "utf-8").toString("base64");
+const AUTH = { Authorization: `Basic ${b64(`admin:${PASSWORD}`)}` };
+
+let env: Env;
+let convs: ConversationsRepo;
+
+beforeEach(async () => {
+  const mf = await createTestMiniflare();
+  const d1 = (await mf.getD1Database("DB")) as any;
+  env = {
+    DB: d1,
+    BOT_NAME: "TestBot",
+    BUSINESS_NAME: "Negocio de Prueba",
+    BOT_LANGUAGE: "es",
+    BOT_TIER: "pro",
+    DASHBOARD_PASSWORD: PASSWORD,
+  } as unknown as Env;
+  convs = new ConversationsRepo(new Db(d1));
+});
+
+describe("el tema de cada canal", () => {
+  it("WhatsApp, Telegram e Instagram tienen el suyo", () => {
+    const wa = temaDelCanal("whatsapp");
+    const tg = temaDelCanal("telegram");
+    expect(wa.nombre).toBe("WhatsApp");
+    expect(tg.nombre).toBe("Telegram");
+    expect(wa.fondo).not.toBe(tg.fondo);
+  });
+
+  it("un canal sin app propia se queda con el tema del panel", () => {
+    const g = temaDelCanal("web");
+    expect(g.fuente).toBe("inherit");
+    expect(colorDeMarca("web")).toBe("var(--accent-2)");
+  });
+
+  // Un WhatsApp que entra por un proveedor intermedio se lee WhatsApp: al equipo
+  // le importa POR DÓNDE le escribió el cliente, no con qué integración.
+  it("el tema sale de la plataforma REAL, no del proveedor", () => {
+    expect(temaDelCanal("zernio", "whatsapp").nombre).toBe("WhatsApp");
+    expect(temaDelCanal("zernio", "telegram").nombre).toBe("Telegram");
+    expect(temaDelCanal("zernio", null).fuente).toBe("inherit");
+  });
+
+  // La cadena de fuentes acaba DENTRO de un atributo style="…": con comillas
+  // dobles el navegador corta el atributo ahí mismo y la fuente nunca se aplica.
+  it("la pila de fuentes usa comillas simples", () => {
+    const estilo = estiloDelTema(temaDelCanal("whatsapp"));
+    expect(estilo).not.toContain('"');
+    expect(estilo).toContain("font-family:");
+  });
+
+  it("el estilo trae todas las variables que usa el hilo", () => {
+    const estilo = estiloDelTema(temaDelCanal("whatsapp"));
+    for (const v of ["--ch-fondo", "--ch-barra", "--ch-propia", "--ch-ajena", "--ch-texto", "--ch-suave", "--ch-marca", "--ch-radio"]) {
+      expect(estilo).toContain(v);
+    }
+  });
+});
+
+describe("el hilo se viste con él", () => {
+  it("un chat de WhatsApp trae las variables del tema", async () => {
+    const conv = await convs.getOrCreate("whatsapp", "51999888777", "Rosa");
+    const html = await (
+      await adminApp.request(
+        `/conversations/thread/${encodeURIComponent(conv.id)}`,
+        { headers: AUTH },
+        env,
+      )
+    ).text();
+    expect(html).toContain("--ch-fondo");
+    expect(html).toContain("background:var(--ch-fondo)");
+  });
+
+  // Alcance deliberado: la lista y los filtros conservan la identidad del panel.
+  it("solo se viste el HILO, no el resto del panel", async () => {
+    const conv = await convs.getOrCreate("telegram", "42", "Cliente");
+    const pagina = await (
+      await adminApp.request(`/conversations?c=${encodeURIComponent(conv.id)}`, { headers: AUTH }, env)
+    ).text();
+    const iHilo = pagina.indexOf("--ch-fondo");
+    expect(iHilo).toBeGreaterThan(-1);
+    // los filtros de la bandeja siguen con el color del panel
+    expect(pagina).toContain("var(--accent)");
+  });
+});


### PR DESCRIPTION
## Por qué

Cuando conectas el número oficial de WhatsApp, **deja de funcionar en la app normal** y tu equipo tiene que atender desde el panel. Si ahí se ve como una terminal, el cambio se siente brusco y se cometen errores: quien lleva años en WhatsApp no reconoce dónde está.

No es decoración — es lo que hace que el traslado al panel sea casi invisible.

## Qué hace

Si la conversación entró por WhatsApp, el hilo **se ve como WhatsApp**: colores, burbujas, esquinas, tipografía. Telegram e Instagram igual. Un canal sin app propia se queda **exactamente como está hoy**.

**Alcance deliberado: solo el hilo** y su cajón de respuesta. La lista, los filtros y las tarjetas conservan la identidad del panel, porque son la herramienta de trabajo, no el chat. Hay una prueba que lo fija.

Las fuentes son las **del sistema** (Roboto / San Francisco), que es lo que de verdad usan esas apps en el teléfono: no se descarga ninguna fuente externa —sería más lento— y las propias de esas marcas no son libres.

## Dos detalles que costaron

- **La pila de fuentes va con comillas simples.** Acaba dentro de un atributo `style="…"`: con comillas dobles el navegador **corta el atributo ahí mismo** y la fuente no se aplica nunca. Hay una prueba dedicada.
- **Un WhatsApp que entra por un proveedor intermedio se lee "WhatsApp"**, no el nombre del proveedor: el tema sale de la **plataforma real**. Al equipo le importa por dónde le escribió el cliente, no con qué integración llegó.

## De paso

La etiqueta de canal de la bandeja lleva el **color de su red** (el verde de WhatsApp, el azul de Telegram): de un vistazo se ve por dónde escribió cada persona, sin leer.

## Pruebas

`npx vitest run --no-file-parallelism` → **444 en verde**, incluidas 7 nuevas: que cada canal tenga su tema, que uno sin app propia no cambie, que el tema salga de la plataforma real, lo de las comillas simples, y que **solo** se vista el hilo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added channel-specific conversation themes for WhatsApp, Telegram, Instagram, Messenger, and other channels.
  - Updated conversation threads, message bubbles, timestamps, empty states, and composer areas with channel-appropriate colors and styling.
  - Added distinct visual treatment for incoming, outgoing, and owner messages.
  - Included a safe fallback theme when no supported channel is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->