### PR TITLE
fix(panel): el teléfono del cliente, siempre visible y copiable

### DIFF
--- a/src/admin/views/conversations.ts
+++ b/src/admin/views/conversations.ts
@@ -209,6 +209,45 @@ export async function renderInboxList(env: Env, p: InboxParams): Promise<string>
 
 // --- Right pane: live thread (header + messages, polled) ----------------------
 
+
+/**
+ * EL TELÉFONO DEL CLIENTE, SIEMPRE VISIBLE Y COPIABLE.
+ *
+ * En cuanto alguien le pone nombre a un contacto, el número desaparecía del
+ * panel — y es lo ÚNICO con lo que el equipo puede contactar a esa persona
+ * desde otro celular, o pasárselo a alguien que no tiene acceso al panel.
+ *
+ * Telegram no finge ser un teléfono: ahí se muestra el id tal cual, porque
+ * escribir "+42" sería mentir.
+ */
+function esTelefono(canal: string | null | undefined): boolean {
+  const c = (canal ?? "").toLowerCase();
+  return c === "whatsapp" || c === "twilio" || c === "meta";
+}
+
+/** "51999888777" -> "+51 999 888 777": se lee, y se copia entero de un clic. */
+function telefonoLegible(id: string): string {
+  const d = (id ?? "").replace(/\D/g, "");
+  if (d.length < 8) return id;
+  return "+" + d.replace(/^(\d{1,3})(\d{3})(\d{3})(\d{3,})$/, "$1 $2 $3 $4");
+}
+
+function bloqueContacto(canal: string | null | undefined, idCanal: string): string {
+  const tel = esTelefono(canal);
+  const visible = tel ? telefonoLegible(idCanal) : idCanal;
+  const crudo = tel ? "+" + (idCanal ?? "").replace(/\D/g, "") : idCanal;
+  const enlace = tel
+    ? `<a href="https://api.whatsapp.com/send?phone=${encodeURIComponent((idCanal ?? "").replace(/\D/g, ""))}" target="_blank" rel="noopener"
+         title="Abrir este chat en tu WhatsApp" style="color:inherit;text-decoration:none;border-bottom:1px dotted currentColor">${escapeHtml(visible)}</a>`
+    : escapeHtml(visible);
+  return `<span style="display:inline-flex;align-items:center;gap:5px;font-size:11px;color:var(--dim)">
+    ${enlace}
+    <button type="button" title="Copiar" aria-label="Copiar el contacto"
+            onclick="navigator.clipboard.writeText('${crudo.replace(/'/g, "")}');this.textContent='✓';setTimeout(()=>this.textContent='⧉',1200)"
+            style="background:none;border:none;color:inherit;cursor:pointer;font-size:11px;padding:0 2px;line-height:1">⧉</button>
+  </span>`;
+}
+
 export async function renderThreadLive(env: Env, convId: string): Promise<string> {
   const db = new Db(env.DB);
   const conv = await db.first<any>("SELECT * FROM conversations WHERE id = ?", [convId]);
@@ -259,7 +298,8 @@ export async function renderThreadLive(env: Env, convId: string): Promise<string
 
   const header = `
   <div style="display:flex;flex-wrap:wrap;align-items:center;gap:8px;padding:12px 16px;border-bottom:1px solid var(--line);background:var(--panel)">
-    <span style="font-family:'Space Grotesk';font-weight:600;font-size:14px;color:var(--cream)">${escapeHtml(conv.display_name ?? conv.channel_user_id)}</span>
+    <span style="font-family:'Space Grotesk';font-weight:600;font-size:14px;color:var(--cream)">${escapeHtml(conv.display_name || "Sin nombre")}</span>
+    ${bloqueContacto(conv.channel, conv.channel_user_id)}
     <span style="${smallPill("var(--info)")}">${escapeHtml(channelLabel(conv.channel))}</span>
     ${statusPill}
     ${sentBadge}

--- a/test/admin/telefono-visible.test.ts
+++ b/test/admin/telefono-visible.test.ts
@@ -1,0 +1,76 @@
+/**
+ * EL TELÉFONO DEL CLIENTE, SIEMPRE VISIBLE Y COPIABLE.
+ *
+ * En cuanto alguien le ponía nombre a un contacto, el número desaparecía del
+ * panel — y es lo único con lo que el equipo puede contactar a esa persona
+ * desde otro celular, o pasárselo a alguien que no tiene acceso al panel.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { createTestMiniflare } from "../helpers/miniflareSetup";
+import { adminApp } from "../../src/admin/routes";
+import { Db } from "../../src/db/client";
+import { ConversationsRepo } from "../../src/db/conversations";
+import type { Env } from "../../src/env";
+
+const PASSWORD = "secret123";
+const b64 = (s: string) =>
+  typeof btoa === "function" ? btoa(s) : Buffer.from(s, "utf-8").toString("base64");
+const AUTH = { Authorization: `Basic ${b64(`admin:${PASSWORD}`)}` };
+
+let env: Env;
+let convs: ConversationsRepo;
+
+beforeEach(async () => {
+  const mf = await createTestMiniflare();
+  const d1 = (await mf.getD1Database("DB")) as any;
+  env = {
+    DB: d1,
+    BOT_NAME: "TestBot",
+    BUSINESS_NAME: "Negocio de Prueba",
+    BOT_LANGUAGE: "es",
+    BOT_TIER: "pro",
+    DASHBOARD_PASSWORD: PASSWORD,
+  } as unknown as Env;
+  convs = new ConversationsRepo(new Db(d1));
+});
+
+const hilo = async (id: string) =>
+  (await adminApp.request(`/conversations/thread/${encodeURIComponent(id)}`, { headers: AUTH }, env)).text();
+
+describe("el contacto en la cabecera", () => {
+  it("el número se ve AUNQUE el contacto ya tenga nombre", async () => {
+    const conv = await convs.getOrCreate("whatsapp", "51999888777", "Rosa Quispe");
+    const html = await hilo(conv.id);
+    expect(html).toContain("Rosa Quispe");
+    expect(html).toContain("+51 999 888 777");
+  });
+
+  it("se puede copiar de un clic", async () => {
+    const conv = await convs.getOrCreate("whatsapp", "51999888777", "Rosa");
+    expect(await hilo(conv.id)).toContain("clipboard.writeText");
+  });
+
+  it("lleva al chat de WhatsApp", async () => {
+    const conv = await convs.getOrCreate("whatsapp", "51999888777", "Rosa");
+    expect(await hilo(conv.id)).toContain("api.whatsapp.com/send?phone=51999888777");
+  });
+
+  it("sin nombre, la cabecera lo dice y el número NO se repite dos veces", async () => {
+    const conv = await convs.getOrCreate("whatsapp", "51999888777");
+    const html = await hilo(conv.id);
+    expect(html).toContain("Sin nombre");
+    expect(html.match(/\+51 999 888 777/g) ?? []).toHaveLength(1);
+  });
+
+  // Telegram no finge ser un teléfono: escribir "+42" sería mentir.
+  it("Telegram muestra su id tal cual, sin disfrazarlo de teléfono", async () => {
+    const conv = await convs.getOrCreate("telegram", "42", "Cliente");
+    const html = await hilo(conv.id);
+    // el id va suelto dentro del bloque de contacto, sin enlace ni formato
+    expect(html).toMatch(/Copiar el contacto/);
+    expect(html).toMatch(/>\s*42\s*</);
+    expect(html).not.toContain("api.whatsapp.com");
+    expect(html).not.toContain("+42");
+  });
+});


### PR DESCRIPTION
## El problema

En cuanto alguien le pone **nombre** a un contacto, el número **desaparecía** de la cabecera del chat: se mostraba `display_name ?? channel_user_id`.

Y ese número es lo único con lo que el equipo puede contactar a esa persona **desde otro celular**, o pasárselo a alguien que no tiene acceso al panel.

## Qué cambia

Se ven **las dos cosas**: el nombre y el contacto. El número va formateado para que se lea (`+51 999 888 777`), se **copia entero de un clic**, y lleva al chat por `api.whatsapp.com`.

- **Telegram no finge ser un teléfono**: ahí se muestra el id tal cual, porque escribir "+42" sería mentir.
- **Sin nombre**, la cabecera dice "Sin nombre" y el número va **una** sola vez, no dos.

## Pruebas

`npx vitest run --no-file-parallelism` → **442 en verde**, incluidas 5 nuevas: que el número se vea aunque haya nombre, que se copie, que enlace a WhatsApp, el caso sin nombre, y que Telegram no se disfrace de teléfono.
