### PR TITLE
feat(panel): devolver el bot en un solo clic, y sin escribir nada en el chat

### DIFF
--- a/src/admin/routes.ts
+++ b/src/admin/routes.ts
@@ -608,12 +608,23 @@ adminApp.post("/conversations/:id/resume", async (c) => {
   // has context when it picks the conversation back up. The summary field is
   // optional, so tolerate a request with no form body (formData() throws on an
   // empty/no-content-type body).
+  //
+  // Devolver el bot NO depende de mandar el formulario: la barra lo hace en el
+  // PRIMER clic. El cuadro que se abre después es opcional —sirve para contarle
+  // al bot algo que pasó fuera del chat— y se puede cerrar sin enviar nada.
+  //
+  // Por eso, cuando la petición viene de HTMX y sin nota se responde vacío:
+  // redibujar el hilo cerraría ese cuadro a media frase.
+  //
+  // Y la nota se guarda SOLO si de verdad se escribió algo: antes se metía una
+  // de oficio y en el chat aparecía un mensaje que nadie había escrito.
   const form = await c.req.formData().catch(() => null);
-  const summary =
-    String(form?.get("summary") ?? "").trim() ||
-    "(El dueño habló con el cliente y resolvió la consulta.)";
-  const msgs = new MessagesRepo(new Db(c.env.DB));
-  await msgs.append(id, "owner", summary);
+  const summary = String(form?.get("summary") ?? "").trim();
+  if (summary) {
+    const msgs = new MessagesRepo(new Db(c.env.DB));
+    await msgs.append(id, "owner", summary);
+  }
+  if (c.req.header("HX-Request") && !summary) return c.body(null, 204);
   return c.redirect(`/admin/conversations?c=${encodeURIComponent(id)}`);
 });
 

--- a/src/admin/views/conversations.ts
+++ b/src/admin/views/conversations.ts
@@ -242,13 +242,17 @@ export async function renderThreadLive(env: Env, convId: string): Promise<string
   const controls = paused
     ? `
     <details style="position:relative;margin-left:auto">
-      <summary class="chip" style="cursor:pointer;list-style:none;font-size:11px;color:var(--accent-2);background:var(--panel2);border:1px solid var(--linelit);padding:6px 11px;display:inline-flex;align-items:center;gap:6px">▸ Devolver al bot</summary>
+      <summary class="chip"
+               hx-post="/admin/conversations/${encodeURIComponent(convId)}/resume"
+               hx-swap="none"
+               title="Devolver el bot: vuelve a responder en este chat"
+               style="cursor:pointer;list-style:none;font-size:11px;color:var(--accent-2);background:var(--panel2);border:1px solid var(--linelit);padding:6px 11px;display:inline-flex;align-items:center;gap:6px">▸ Devolver bot</summary>
       <form method="POST" action="/admin/conversations/${encodeURIComponent(convId)}/resume"
             style="position:absolute;right:0;z-index:10;margin-top:8px;width:280px;background:var(--panel);border:1px solid var(--linelit);box-shadow:6px 6px 0 rgba(0,0,0,.4);padding:12px">
         <p style="font-size:11px;color:var(--muted);margin:0 0 8px">Cuéntale al bot qué resolviste para que siga con contexto.</p>
         <textarea name="summary" rows="3" required placeholder="Ej. Ya le confirmé su pago y le di acceso."
                   style="width:100%;background:var(--bg);border:1px solid var(--line);color:var(--cream);padding:8px 10px;font-size:12px;outline:none;resize:vertical;margin-bottom:8px"></textarea>
-        <button class="bigbtn" style="width:100%;background:var(--accent);border:1px solid var(--accent);color:#1a1206;box-shadow:3px 3px 0 var(--linelit);padding:9px;font-size:12px;font-weight:700;font-family:'Space Grotesk';cursor:pointer">Devolver al bot</button>
+        <button class="bigbtn" style="width:100%;background:var(--accent);border:1px solid var(--accent);color:#1a1206;box-shadow:3px 3px 0 var(--linelit);padding:9px;font-size:12px;font-weight:700;font-family:'Space Grotesk';cursor:pointer">Enviar al bot</button>
       </form>
     </details>`
     : `

--- a/test/admin/devolver-bot-un-clic.test.ts
+++ b/test/admin/devolver-bot-un-clic.test.ts
@@ -1,0 +1,89 @@
+/**
+ * DEVOLVER EL BOT EN UN SOLO CLIC.
+ *
+ * Antes hacían falta dos: uno para abrir el cuadro y otro para confirmar. Y si
+ * no escribías nada, el sistema metía en el chat una nota de oficio que nadie
+ * había escrito.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { createTestMiniflare } from "../helpers/miniflareSetup";
+import { adminApp } from "../../src/admin/routes";
+import { Db } from "../../src/db/client";
+import { ConversationsRepo } from "../../src/db/conversations";
+import { MessagesRepo } from "../../src/db/messages";
+import type { Env } from "../../src/env";
+
+const PASSWORD = "secret123";
+const b64 = (s: string) =>
+  typeof btoa === "function" ? btoa(s) : Buffer.from(s, "utf-8").toString("base64");
+const AUTH = { Authorization: `Basic ${b64(`admin:${PASSWORD}`)}` };
+const FORM = { ...AUTH, "Content-Type": "application/x-www-form-urlencoded" };
+
+let env: Env;
+let convs: ConversationsRepo;
+let msgs: MessagesRepo;
+
+beforeEach(async () => {
+  const mf = await createTestMiniflare();
+  const d1 = (await mf.getD1Database("DB")) as any;
+  env = {
+    DB: d1,
+    BOT_NAME: "TestBot",
+    BUSINESS_NAME: "Negocio de Prueba",
+    BOT_LANGUAGE: "es",
+    BOT_TIER: "pro",
+    DASHBOARD_PASSWORD: PASSWORD,
+  } as unknown as Env;
+  const db = new Db(d1);
+  convs = new ConversationsRepo(db);
+  msgs = new MessagesRepo(db);
+});
+
+describe("un solo clic", () => {
+  it("el primer clic devuelve el bot, sin escribir ni enviar nada", async () => {
+    const conv = await convs.getOrCreate("whatsapp", "51999", "Rosa");
+    await convs.setPausedUntil(conv.id, Date.now() + 60_000);
+
+    const res = await adminApp.request(
+      `/conversations/${encodeURIComponent(conv.id)}/resume`,
+      { method: "POST", headers: { ...AUTH, "HX-Request": "true" } },
+      env,
+    );
+
+    expect(await convs.isPaused(conv.id)).toBe(false);
+    // sin redibujar el hilo, que cerraría el cuadro a media frase
+    expect(res.status).toBe(204);
+    // y sin ensuciar el chat con una nota de oficio
+    expect(await msgs.lastN(conv.id, 10)).toHaveLength(0);
+  });
+
+  it("el chip de la barra lo hace en el mismo clic", async () => {
+    const conv = await convs.getOrCreate("whatsapp", "51888", "Rosa");
+    await convs.setPausedUntil(conv.id, Date.now() + 60_000);
+    const html = await (
+      await adminApp.request(
+        `/conversations/thread/${encodeURIComponent(conv.id)}`,
+        { headers: AUTH },
+        env,
+      )
+    ).text();
+    expect(html).toMatch(/<summary[^>]*hx-post="[^"]+\/resume"[^>]*hx-swap="none"/);
+    // el botón de dentro ya no dice "devolver": solo manda la nota
+    expect(html).toContain("Enviar al bot");
+  });
+
+  it("si escribes una nota, se guarda y el bot vuelve igual", async () => {
+    const conv = await convs.getOrCreate("whatsapp", "51777", "Rosa");
+    await convs.setPausedUntil(conv.id, Date.now() + 60_000);
+    await adminApp.request(
+      `/conversations/${encodeURIComponent(conv.id)}/resume`,
+      { method: "POST", headers: FORM, body: new URLSearchParams({ summary: "le confirmé el pago" }) },
+      env,
+    );
+    const historia = await msgs.lastN(conv.id, 5);
+    expect(historia).toHaveLength(1);
+    expect(historia[0].content).toContain("le confirmé el pago");
+    expect(await convs.isPaused(conv.id)).toBe(false);
+  });
+});


### PR DESCRIPTION
## El problema

Hacían falta **dos clics**: uno para abrir el cuadro y otro para confirmar. El segundo botón no aportaba nada — solo estorbaba.

Y si **no escribías nada**, `/resume` metía en el chat una nota de oficio — *"(El dueño habló con el cliente y resolvió la consulta.)"* — o sea, un mensaje que nadie había escrito, apareciendo en la conversación.

## Qué cambia

El **primer clic** en la barra ya devuelve el bot (`hx-post` con `hx-swap="none"`, para no redibujar el hilo y cerrar el cuadro a media frase).

El cuadro que se abre es **opcional**: sirve para contarle al bot algo que pasó **fuera** del chat, su botón se llama ahora **"Enviar al bot"**, y se puede cerrar con la ✕ sin mandar nada — porque el bot ya volvió.

Y la nota se guarda **solo si de verdad se escribió algo**.

## Nota para quien revise

⚠️ Este PR toca las **mismas líneas de `/resume`** que el de las notas internas (marcar lo que el equipo le escribe al bot para que no parezca un mensaje enviado). Cualquiera de los dos puede entrar primero; el segundo necesitará un rebase de tres líneas.

## Pruebas

`npx vitest run --no-file-parallelism` → **440 en verde**, incluidas 3 nuevas: que el primer clic devuelva el bot sin escribir nada (204 y cero mensajes nuevos), que el chip lleve el `hx-post`, y que si escribes una nota se guarde igual.
