### PR TITLE
Arregla el SyntaxError del selector de proyectos en todas las paginas del panel

### DIFF
--- a/src/admin/views/layout.ts
+++ b/src/admin/views/layout.ts
@@ -348,9 +348,13 @@ export function layout(opts: { title: string; activeTab: string; body: string; e
     d.peers.forEach(function(p){
       opts += '<option value="' + p.url.replace(/"/g,'&quot;') + '">' + p.name.replace(/</g,'&lt;') + '</option>';
     });
-    el.innerHTML = '<select onchange="if(this.value.indexOf(\'http\')===0)window.location=this.value" ' +
+    // Las comillas simples van como &#39;: este bloque vive dentro de un
+    // template literal, así que los \' del código fuente NO llegan al navegador
+    // y cerraban la cadena JS de golpe (SyntaxError en cada carga del panel).
+    // El parser de HTML las decodifica antes de que corran el onchange y el CSS.
+    el.innerHTML = '<select onchange="if(this.value.indexOf(&#39;http&#39;)===0)window.location=this.value" ' +
       'style="background:rgba(20,16,9,.9);color:var(--fg,#e8e0cf);border:1px solid var(--line);border-radius:8px;' +
-      'padding:6px 10px;font-family:\'JetBrains Mono\',monospace;font-size:11px;letter-spacing:.04em;cursor:pointer" ' +
+      'padding:6px 10px;font-family:&#39;JetBrains Mono&#39;,monospace;font-size:11px;letter-spacing:.04em;cursor:pointer" ' +
       'title="Cambiar de proyecto">' + opts + '</select>';
   }).catch(function(){});
   </script>

--- a/test/admin/layout-scripts.test.ts
+++ b/test/admin/layout-scripts.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Los <script> del panel tienen que PARSEAR.
+ *
+ * El selector de proyectos armaba su HTML con comillas simples escapadas (\')
+ * dentro de un template literal, así que la barra invertida se perdía y al
+ * navegador le llegaba una cadena JS cortada por la mitad:
+ *
+ *   '<select onchange="if(this.value.indexOf('http')===0)…" '
+ *
+ * Resultado: "Uncaught SyntaxError: Unexpected identifier 'http'" en TODAS las
+ * páginas del panel, y ese bloque entero no se ejecutaba nunca (el selector de
+ * proyectos no aparecía aunque hubiera PEER_BOTS configurados).
+ *
+ * Un error de sintaxis solo se ve abriendo la consola del navegador, así que
+ * esta prueba lo comprueba desde el servidor: coge cada script en línea del
+ * HTML y lo pasa por el parser de JavaScript.
+ */
+import { describe, it, expect } from "vitest";
+import { layout } from "../../src/admin/views/layout";
+
+const RE_SCRIPT_EN_LINEA = /<script(?![^>]*\ssrc=)[^>]*>([\s\S]*?)<\/script>/g;
+
+function scriptsDe(html: string): string[] {
+  return [...html.matchAll(RE_SCRIPT_EN_LINEA)].map((m) => m[1]).filter((s) => s.trim());
+}
+
+describe("los scripts en línea del panel", () => {
+  const html = layout({ title: "Prueba", activeTab: "overview", body: "<p>hola</p>" });
+
+  it("hay scripts que revisar (si no, la prueba no probaría nada)", () => {
+    expect(scriptsDe(html).length).toBeGreaterThan(0);
+  });
+
+  it("todos parsean como JavaScript válido", () => {
+    for (const script of scriptsDe(html)) {
+      expect(() => new Function(script)).not.toThrow();
+    }
+  });
+
+  it("el selector de proyectos escapa sus comillas como &#39;", () => {
+    // Si vuelven los \' del código fuente, el navegador recibe 'http' suelto
+    // dentro de una cadena ya delimitada por comillas simples.
+    expect(html).toContain("indexOf(&#39;http&#39;)");
+    expect(html).not.toContain("indexOf('http')");
+  });
+});


### PR DESCRIPTION
## El problema

El `<script>` del selector de proyectos (`src/admin/views/layout.ts`) arma su HTML con comillas simples escapadas (`\'`) **dentro de un template literal**. El template literal se come la barra invertida, así que al navegador le llega la cadena cortada a media frase:

```js
el.innerHTML = '<select onchange="if(this.value.indexOf('http')===0)…" ' +
  'padding:6px 10px;font-family:'JetBrains Mono',monospace;…" ' +
```

Las comillas de `'http'` y de `'JetBrains Mono'` cierran la cadena JS antes de tiempo.

**Efecto:** `Uncaught SyntaxError: Unexpected identifier 'http'` en la consola en **cada carga de cada página del panel**, y ese bloque no se ejecuta nunca — el selector de proyectos no aparece aunque `PEER_BOTS` esté configurado.

## Cómo verlo

Abrir `/admin` con la consola del navegador abierta. Sale en Resumen, Conversaciones, Config… en todas. Lo encontré revisando otra cosa en un bot en producción.

## El arreglo

Las comillas van como `&#39;`, que el parser de HTML decodifica **antes** de que corran el `onchange` y el CSS. Es el escape correcto dentro de un atributo, y no depende de cómo se transporte la cadena en el código fuente.

## La prueba

`test/admin/layout-scripts.test.ts` coge cada `<script>` en línea del HTML del layout y lo pasa por el parser de JavaScript. Un error de sintaxis solo se ve abriendo la consola del navegador; así queda cubierto desde el servidor y no puede volver sin que salte una prueba.

`npx tsc --noEmit` limpio y las 3 pruebas nuevas en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed project switching in the admin panel when project details contain apostrophes.
  * Prevented malformed inline scripts and styling from interrupting project selection.

* **Tests**
  * Added coverage to verify that rendered admin scripts remain valid and safely escape special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->