### PR TITLE
Notas de voz: grabar desde el panel y enviarlas por WhatsApp

### DIFF
--- a/src/admin/routes.ts
+++ b/src/admin/routes.ts
@@ -12,6 +12,14 @@
  * middleware that has access to `c.env` rather than at module-init time.
  */
 import { parsePeerBots } from "./projects";
+import {
+  MAX_BYTES_AUDIO,
+  enviarNotaDeVoz,
+  formatoGrabable,
+  motivoEntendible,
+  telefonoDe,
+  tipoBase,
+} from "../media/notaDeVoz";
 import { Hono } from "hono";
 import { generateText } from "ai";
 import { createModel } from "../llm/provider";
@@ -584,6 +592,69 @@ adminApp.post("/conversations/:id/reply", async (c) => {
   c.header("X-Sent", "1");
   return c.html(
     `<span class="text-emerald-600">✓ Enviado por ${escapeHtml(channelLabel(conv.channel))}</span>` +
+      `<div id="thread-live" hx-swap-oob="innerHTML">${await renderThreadLive(c.env, id)}</div>`,
+  );
+});
+
+/**
+ * NOTA DE VOZ: se graba en el panel, se manda por WhatsApp y el bot se pausa,
+ * igual que al responder por escrito. Si una persona del equipo acaba de
+ * hablarle con su voz, lo último que puede pasar es que el bot conteste encima.
+ *
+ * El orden importa: PRIMERO se envía. Si WhatsApp lo rechaza no se guarda nada
+ * ni se pausa nada, para que el hilo nunca muestre un audio que no llegó (misma
+ * regla que /reply).
+ */
+adminApp.post("/conversations/:id/audio", async (c) => {
+  const id = c.req.param("id");
+  const db = new Db(c.env.DB);
+  const convs = new ConversationsRepo(db);
+  const conv = await convs.getById(id);
+  if (!conv) return c.html(`<span class="text-red-600">✗ Conversación no encontrada.</span>`);
+
+  const form = await c.req.formData().catch(() => null);
+  // Se comprueba por forma, no con `instanceof File`: en los tipos del worker
+  // el valor del formulario no es la clase File del DOM.
+  const archivo = form?.get("audio") as
+    | { size?: number; type?: string; arrayBuffer?: () => Promise<ArrayBuffer> }
+    | null;
+  if (!archivo || typeof archivo.arrayBuffer !== "function" || !archivo.size) {
+    return c.html(`<span class="text-stone-400">No llegó ninguna grabación.</span>`);
+  }
+  if (archivo.size > MAX_BYTES_AUDIO) {
+    return c.html(
+      `<span class="text-red-600">✗ La grabación pesa demasiado (el tope de WhatsApp son 16 MB).</span>`,
+    );
+  }
+  const mime = tipoBase(archivo.type || "");
+  if (!formatoGrabable(mime)) {
+    return c.html(
+      `<span class="text-red-600">✗ WhatsApp no acepta el formato «${escapeHtml(mime || "desconocido")}».</span>`,
+    );
+  }
+
+  const telefono = telefonoDe(conv.channel_user_id);
+  if (!telefono) {
+    return c.html(
+      `<span class="text-red-600">✗ Este contacto no tiene un número de WhatsApp válido. Respóndele por escrito.</span>`,
+    );
+  }
+
+  try {
+    await enviarNotaDeVoz(c.env, telefono, await archivo.arrayBuffer(), mime);
+  } catch (e) {
+    console.error("[nota-de-voz] no se pudo enviar:", e);
+    return c.html(`<span class="text-red-600">✗ ${escapeHtml(motivoEntendible(e))}</span>`);
+  }
+
+  const msgs = new MessagesRepo(db);
+  await msgs.append(id, "owner", "🎤 Nota de voz del equipo.");
+  await convs.touchLastMessage(id);
+  await convs.setPausedUntil(id, Date.now() + TAKEOVER_MS);
+
+  c.header("X-Sent", "1");
+  return c.html(
+    `<span class="text-emerald-600">✓ Nota de voz enviada. El bot queda pausado en este chat.</span>` +
       `<div id="thread-live" hx-swap-oob="innerHTML">${await renderThreadLive(c.env, id)}</div>`,
   );
 });

--- a/src/admin/views/conversations.ts
+++ b/src/admin/views/conversations.ts
@@ -328,7 +328,7 @@ function renderComposer(convId: string): string {
   return `
   <div style="border-top:1px solid var(--line);background:var(--panel);padding:12px;display:flex;flex-direction:column;gap:8px">
     <div id="suggestion-box"></div>
-    <form hx-post="/admin/conversations/${id}/reply" hx-target="#send-status" hx-swap="innerHTML"
+    <form id="fila-escribir" hx-post="/admin/conversations/${id}/reply" hx-target="#send-status" hx-swap="innerHTML"
           hx-on::after-request="if(event.detail.xhr.getResponseHeader('X-Sent')==='1')this.reset()"
           style="display:flex;align-items:flex-end;gap:9px">
       <textarea name="text" id="reply-text" rows="2" required
@@ -338,13 +338,176 @@ function renderComposer(convId: string): string {
               class="chip" style="background:var(--panel2);border:1px solid var(--linelit);color:var(--accent-2);padding:11px 13px;font-size:12px;font-weight:600;cursor:pointer;white-space:nowrap;display:flex;align-items:center;gap:6px" title="El co-pilot sugiere una respuesta">
         <i data-lucide="sparkles" width="13" height="13"></i> Sugerir
       </button>
+      <button type="button" id="btn-grabar" class="chip"
+              style="background:var(--panel2);border:1px solid var(--linelit);color:var(--accent-2);width:42px;height:42px;flex:none;padding:0;cursor:pointer;display:flex;align-items:center;justify-content:center"
+              title="Grabar una nota de voz, enviarla y pausar el bot">
+        <i data-lucide="mic" width="15" height="15"></i>
+      </button>
       <button type="submit" class="bigbtn" style="background:var(--accent);border:1px solid var(--accent);color:#1a1206;box-shadow:4px 4px 0 var(--linelit);padding:11px 18px;font-size:12.5px;font-weight:700;font-family:'Space Grotesk';cursor:pointer;white-space:nowrap;display:flex;align-items:center;gap:6px">
         Enviar <i data-lucide="send" width="14" height="14"></i>
       </button>
     </form>
+    ${BARRA_GRABANDO}
+    <form id="form-audio" hx-post="/admin/conversations/${id}/audio" hx-target="#send-status"
+          hx-swap="innerHTML" hx-encoding="multipart/form-data" style="display:none">
+      <input type="file" name="audio" id="campo-audio" accept="audio/*">
+    </form>
     <div id="send-status" style="font-size:11px;min-height:1rem;color:var(--muted)"></div>
+    ${SCRIPT_GRABADORA}
   </div>`;
 }
+
+/**
+ * LA BARRA DE GRABACIÓN, con los controles que la gente ya conoce de WhatsApp.
+ *
+ * Mientras se graba OCUPA EL SITIO del cuadro de escribir: papelera para
+ * descartar, pausa/seguir, el tiempo corriendo y el avioncito para enviar. Sin
+ * papelera, grabarse por error y no poder borrarlo sin enviarlo es una trampa —
+ * y en el celular no existe la tecla Escape.
+ */
+const BARRA_GRABANDO = `
+    <div id="barra-grabando" style="display:none;align-items:center;gap:10px">
+      <button type="button" id="grab-tirar" title="Descartar la grabación"
+              style="background:transparent;border:1px solid var(--bad);color:var(--bad);width:42px;height:42px;flex:none;padding:0;cursor:pointer;display:flex;align-items:center;justify-content:center">
+        <i data-lucide="trash-2" width="15" height="15"></i>
+      </button>
+      <button type="button" id="grab-pausa" title="Pausar o seguir grabando"
+              style="flex:1;min-width:0;background:var(--bg);border:1px solid var(--line);color:var(--cream);height:42px;padding:0 14px;cursor:pointer;display:flex;align-items:center;justify-content:center;gap:9px;font-size:12.5px">
+        <i data-lucide="pause" width="14" height="14" id="grab-icono-pausa"></i>
+        <i data-lucide="play" width="14" height="14" id="grab-icono-seguir" style="display:none"></i>
+        <span id="grab-etiqueta">Pausar</span>
+        <span id="grab-tiempo" style="margin-left:auto;font-variant-numeric:tabular-nums;color:var(--muted)">0:00</span>
+      </button>
+      <button type="button" id="grab-enviar" title="Enviar la nota de voz"
+              style="background:var(--accent);border:1px solid var(--accent);color:#1a1206;width:42px;height:42px;flex:none;padding:0;cursor:pointer;display:flex;align-items:center;justify-content:center">
+        <i data-lucide="send" width="15" height="15"></i>
+      </button>
+    </div>`;
+
+/**
+ * La grabadora del navegador.
+ *
+ * EL ORDEN DE FORMATOS IMPORTA:
+ *  1. ogg/opus — lo que WhatsApp quiere; solo lo graba Firefox.
+ *  2. webm/opus — lo de Chrome. MISMO sonido, otra caja: el worker le cambia la
+ *     caja a ogg y sale como nota de voz de verdad (media/oggOpus).
+ *  3. mp4 — último recurso. Chrome lo graba fragmentado y WhatsApp no lo
+ *     entrega; se manda como adjunto.
+ *
+ * Y hay que SOLTAR EL MICRÓFONO al terminar (`track.stop()`): si no, el
+ * navegador se queda con la luz de "grabando" encendida.
+ */
+const SCRIPT_GRABADORA = `
+<script>
+(function(){
+  var boton = document.getElementById('btn-grabar');
+  if (!boton) return;
+  var estado = document.getElementById('send-status');
+  var campo = document.getElementById('campo-audio');
+  var formulario = document.getElementById('form-audio');
+  var fila = document.getElementById('fila-escribir');
+  var barra = document.getElementById('barra-grabando');
+  var btnTirar = document.getElementById('grab-tirar');
+  var btnPausa = document.getElementById('grab-pausa');
+  var btnEnviar = document.getElementById('grab-enviar');
+  var etiqueta = document.getElementById('grab-etiqueta');
+  var tiempo = document.getElementById('grab-tiempo');
+  var iconoPausa = document.getElementById('grab-icono-pausa');
+  var iconoSeguir = document.getElementById('grab-icono-seguir');
+  var grabadora = null, pedazos = [], pista = null, reloj = null, segundos = 0, cancelado = false;
+
+  var CANDIDATOS = ['audio/ogg;codecs=opus','audio/ogg','audio/webm;codecs=opus','audio/webm','audio/mp4','audio/aac','audio/mpeg'];
+  function formatoServible(){
+    if (!window.MediaRecorder) return null;
+    for (var i=0;i<CANDIDATOS.length;i++){
+      if (MediaRecorder.isTypeSupported(CANDIDATOS[i])) return CANDIDATOS[i];
+    }
+    return null;
+  }
+  function aviso(msg, malo){
+    estado.innerHTML = '<span style="color:' + (malo ? '#d97a6a' : 'inherit') + '">' + msg + '</span>';
+  }
+  function pinta(){
+    var m = Math.floor(segundos/60), s = segundos % 60;
+    tiempo.textContent = m + ':' + (s<10?'0':'') + s;
+  }
+  function corre(si){
+    if (reloj) { clearInterval(reloj); reloj = null; }
+    if (si) reloj = setInterval(function(){ segundos++; pinta(); }, 1000);
+  }
+  function modoGrabando(si){
+    fila.style.display = si ? 'none' : 'flex';
+    barra.style.display = si ? 'flex' : 'none';
+  }
+  function reposo(){
+    corre(false);
+    if (pista) { pista.getTracks().forEach(function(t){ t.stop(); }); pista = null; }
+    grabadora = null; segundos = 0;
+    pinta();
+    modoGrabando(false);
+    iconoPausa.style.display = '';
+    iconoSeguir.style.display = 'none';
+    etiqueta.textContent = 'Pausar';
+  }
+
+  boton.addEventListener('click', async function(){
+    if (grabadora) return;
+    var tipo = formatoServible();
+    if (!tipo) { aviso('Este navegador no puede grabar audio. Abre el panel en el celular.', true); return; }
+    try {
+      pista = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (e) {
+      aviso('No se pudo usar el micrófono. Revisa el permiso del navegador.', true);
+      return;
+    }
+    cancelado = false;
+    pedazos = [];
+    grabadora = new MediaRecorder(pista, { mimeType: tipo });
+    grabadora.ondataavailable = function(e){ if (e.data && e.data.size) pedazos.push(e.data); };
+    grabadora.onstop = function(){
+      var tipoLimpio = tipo.split(';')[0];
+      var trozo = new Blob(pedazos, { type: tipoLimpio });
+      reposo();
+      if (cancelado) { aviso('Grabación descartada.'); return; }
+      if (!trozo.size) { aviso('No se grabó nada.', true); return; }
+      var dt = new DataTransfer();
+      var ext = tipoLimpio === 'audio/mpeg' ? 'mp3' : tipoLimpio.split('/')[1];
+      dt.items.add(new File([trozo], 'nota-de-voz.' + ext, { type: tipoLimpio }));
+      campo.files = dt.files;
+      aviso('Enviando la nota de voz…');
+      if (window.htmx) htmx.trigger(formulario, 'submit'); else formulario.requestSubmit();
+    };
+    grabadora.start();
+    segundos = 0; pinta();
+    modoGrabando(true);
+    corre(true);
+    aviso('Grabando…');
+  });
+
+  btnPausa.addEventListener('click', function(){
+    if (!grabadora) return;
+    if (grabadora.state === 'recording') {
+      grabadora.pause(); corre(false);
+      iconoPausa.style.display = 'none'; iconoSeguir.style.display = '';
+      etiqueta.textContent = 'Seguir'; aviso('Grabación en pausa.');
+    } else if (grabadora.state === 'paused') {
+      grabadora.resume(); corre(true);
+      iconoPausa.style.display = ''; iconoSeguir.style.display = 'none';
+      etiqueta.textContent = 'Pausar'; aviso('Grabando…');
+    }
+  });
+
+  btnTirar.addEventListener('click', function(){
+    if (grabadora) { cancelado = true; grabadora.stop(); }
+  });
+  btnEnviar.addEventListener('click', function(){
+    if (grabadora) grabadora.stop();
+  });
+  document.addEventListener('keydown', function(e){
+    if (e.key === 'Escape' && grabadora) { cancelado = true; grabadora.stop(); }
+  });
+})();
+</script>`;
 
 /** Fragment returned by /suggest — suggestion + a "use it" button that fills the textarea. */
 export function renderSuggestionBox(text: string): string {

--- a/src/media/notaDeVoz.ts
+++ b/src/media/notaDeVoz.ts
@@ -1,0 +1,227 @@
+/**
+ * NOTAS DE VOZ DEL EQUIPO — grabar desde el panel y mandarlo por WhatsApp.
+ *
+ * Para qué sirve: en mitad de una conversación con el bot, una persona del
+ * equipo graba diez segundos con su voz. Quien está del otro lado deja de
+ * hablarle a un sistema y oye a alguien. Después el bot sigue.
+ *
+ * El envío va por la Cloud API de Meta, que es la que ya usa `channels/whatsapp`.
+ *
+ * EL FORMATO ES TODO EL PROBLEMA, y no es evidente:
+ *  · WhatsApp solo trata como NOTA DE VOZ el audio **Opus dentro de un OGG**.
+ *  · El navegador no sabe grabar eso. Chrome graba `audio/mp4` —que Meta acepta
+ *    al subir, NO entrega (error 131053) y el celular tampoco reproduce— o
+ *    `audio/webm`, que WhatsApp ni admite.
+ *  · Pero el webm de Chrome YA lleva Opus dentro. Solo hay que cambiarle la
+ *    caja, y eso lo hace `media/oggOpus` sin recomprimir ni depender de nada.
+ */
+import type { Env } from "../env";
+import { webmOpusAOgg } from "./oggOpus";
+
+const GRAPH_VERSION = "v21.0";
+
+/** Formatos de audio que WhatsApp acepta. `audio/webm` NO está: se convierte. */
+export const FORMATOS_WHATSAPP = [
+  "audio/ogg",
+  "audio/mp4",
+  "audio/aac",
+  "audio/mpeg",
+  "audio/amr",
+] as const;
+
+/** Tope de WhatsApp para audio. */
+export const MAX_BYTES_AUDIO = 16 * 1024 * 1024;
+
+/** `audio/ogg;codecs=opus` → `audio/ogg` (Meta rechaza el tipo con parámetros). */
+export function tipoBase(mime: string): string {
+  return (mime || "").split(";")[0].trim().toLowerCase();
+}
+
+export function formatoAceptado(mime: string): boolean {
+  return (FORMATOS_WHATSAPP as readonly string[]).includes(tipoBase(mime));
+}
+
+/** Lo que el panel acepta del navegador: lo de WhatsApp más el webm que se convierte. */
+export function formatoGrabable(mime: string): boolean {
+  const t = tipoBase(mime);
+  return formatoAceptado(t) || t === "audio/webm";
+}
+
+/**
+ * ¿Este identificador de conversación es un teléfono al que se pueda mandar?
+ * No todos lo son aunque el canal sea WhatsApp: hay proveedores que identifican
+ * al contacto con algo que no es un número. Antes que mandarle la voz de
+ * alguien a un número equivocado, no se manda. E.164: de 8 a 15 dígitos.
+ */
+export function telefonoDe(channelUserId: string): string | null {
+  const crudo = (channelUserId || "").trim();
+  if (/[a-z]/i.test(crudo)) return null;
+  const digitos = crudo.replace(/\D/g, "");
+  return digitos.length >= 8 && digitos.length <= 15 ? digitos : null;
+}
+
+/**
+ * ¿Este MP4 es de los "fragmentados"?
+ *
+ * 🪤 Meta ACEPTA la subida y ACEPTA el envío —devuelve su id de mensaje— de un
+ * audio que después no puede procesar, y el fallo solo aparece más tarde por el
+ * webhook de estados: `131053 … uploaded with mimetype as audio/mp4, however on
+ * processing it is of type application/octet-stream`. El archivo es un MP4
+ * legítimo (empieza por `ftyp`), pero es *fragmentado* —lo que graba
+ * `MediaRecorder`— y su analizador no lo reconoce.
+ *
+ * 🚫 Preguntarle a Meta `GET /<media_id>` NO sirve: devuelve el mime que le
+ * declaraste tú, no el que detecta. Probado y descartado. Lo que sí distingue el
+ * archivo es su estructura: los fragmentados llevan cajas `moof`.
+ */
+export function mp4EsFragmentado(bytes: ArrayBuffer): boolean {
+  const vista = new Uint8Array(bytes, 0, Math.min(bytes.byteLength, 1_000_000));
+  for (let i = 0; i + 3 < vista.length; i++) {
+    if (vista[i] === 0x6d && vista[i + 1] === 0x6f && vista[i + 2] === 0x6f && vista[i + 3] === 0x66) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** ¿Puede viajar como nota de voz, o hay que mandarlo como adjunto? */
+export function vaComoNotaDeVoz(tipo: string, bytes: ArrayBuffer): boolean {
+  if (tipo === "audio/mp4") return !mp4EsFragmentado(bytes);
+  return (FORMATOS_WHATSAPP as readonly string[]).includes(tipo);
+}
+
+function credenciales(env: Env): { phoneId: string; token: string } {
+  const phoneId = (env.WHATSAPP_PHONE_NUMBER_ID || "").trim();
+  const token = (env.WHATSAPP_ACCESS_TOKEN || "").trim();
+  if (!phoneId || !token) {
+    throw new Error("Falta configurar WhatsApp (WHATSAPP_PHONE_NUMBER_ID o WHATSAPP_ACCESS_TOKEN).");
+  }
+  return { phoneId, token };
+}
+
+/**
+ * Arma el multipart A MANO, en un solo bloque de bytes.
+ *
+ * Con `FormData` el cuerpo puede irse en *chunked* y la subida morir con un
+ * "Network connection lost" que parece un problema de red y no lo es. Con el
+ * cuerpo montado, la petición lleva su tamaño exacto.
+ */
+export function cuerpoMultipart(
+  bytes: ArrayBuffer,
+  tipo: string,
+  nombreArchivo: string,
+): { cuerpo: Uint8Array; contentType: string } {
+  const frontera = `----forja${crypto.randomUUID().replace(/-/g, "")}`;
+  const enc = new TextEncoder();
+  const campo = (nombre: string, valor: string) =>
+    `--${frontera}\r\nContent-Disposition: form-data; name="${nombre}"\r\n\r\n${valor}\r\n`;
+
+  const inicio = enc.encode(
+    campo("messaging_product", "whatsapp") +
+      campo("type", tipo) +
+      `--${frontera}\r\n` +
+      `Content-Disposition: form-data; name="file"; filename="${nombreArchivo}"\r\n` +
+      `Content-Type: ${tipo}\r\n\r\n`,
+  );
+  const fin = enc.encode(`\r\n--${frontera}--\r\n`);
+  const archivo = new Uint8Array(bytes);
+
+  const cuerpo = new Uint8Array(inicio.length + archivo.length + fin.length);
+  cuerpo.set(inicio, 0);
+  cuerpo.set(archivo, inicio.length);
+  cuerpo.set(fin, inicio.length + archivo.length);
+  return { cuerpo, contentType: `multipart/form-data; boundary=${frontera}` };
+}
+
+/** Sube los bytes a Meta y devuelve el id del media. */
+export async function subirAudioAMeta(env: Env, bytes: ArrayBuffer, mime: string): Promise<string> {
+  const { phoneId, token } = credenciales(env);
+  const tipo = tipoBase(mime);
+  const ext = tipo === "audio/mpeg" ? "mp3" : tipo === "audio/mp4" ? "m4a" : tipo.split("/")[1];
+  const { cuerpo, contentType } = cuerpoMultipart(bytes, tipo, `nota-de-voz.${ext}`);
+
+  const res = await fetch(`https://graph.facebook.com/${GRAPH_VERSION}/${phoneId}/media`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": contentType },
+    body: cuerpo,
+  });
+  const respuesta = await res.text();
+  if (!res.ok) throw new Error(`Meta rechazó el audio (${res.status}): ${respuesta.slice(0, 300)}`);
+  const id = (JSON.parse(respuesta) as { id?: string }).id;
+  if (!id) throw new Error("Meta no devolvió el identificador del audio.");
+  return id;
+}
+
+/**
+ * Manda la nota de voz a un teléfono. Devuelve el id del mensaje en Meta.
+ *
+ * ⏰ Aplica la ventana de 24 horas de WhatsApp: fuera de ella Meta rechaza
+ * cualquier mensaje que no sea una plantilla, y una plantilla no lleva audio.
+ */
+export async function enviarNotaDeVoz(
+  env: Env,
+  telefono: string,
+  bytes: ArrayBuffer,
+  mime: string,
+): Promise<string> {
+  const { phoneId, token } = credenciales(env);
+  let tipo = tipoBase(mime);
+  let contenidoAudio = bytes;
+
+  // El webm del navegador ya lleva Opus: se le cambia la caja a OGG y entonces
+  // WhatsApp lo trata como NOTA DE VOZ, con su ondita.
+  if (tipo === "audio/webm") {
+    const ogg = webmOpusAOgg(bytes);
+    if (ogg) {
+      contenidoAudio = ogg.buffer.slice(ogg.byteOffset, ogg.byteOffset + ogg.byteLength) as ArrayBuffer;
+      tipo = "audio/ogg";
+    } else {
+      console.warn("[nota-de-voz] no se pudo convertir el webm — va como adjunto");
+    }
+  }
+
+  const mediaId = await subirAudioAMeta(env, contenidoAudio, tipo);
+
+  // Si el archivo no es de los que WhatsApp procesa, mandarlo como audio acaba
+  // en un 131053 que aparece tarde y deja a la persona sin nada. Como adjunto
+  // sí llega: WhatsApp no procesa los documentos, los entrega.
+  const reconocido = vaComoNotaDeVoz(tipo, contenidoAudio);
+  const ext = tipo === "audio/mpeg" ? "mp3" : tipo === "audio/mp4" ? "m4a" : tipo.split("/")[1];
+  const contenido = reconocido
+    ? { type: "audio", audio: { id: mediaId } }
+    : { type: "document", document: { id: mediaId, filename: `Nota de voz.${ext}` } };
+
+  const res = await fetch(`https://graph.facebook.com/${GRAPH_VERSION}/${phoneId}/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify({
+      messaging_product: "whatsapp",
+      recipient_type: "individual",
+      to: telefono,
+      ...contenido,
+    }),
+  });
+  const cuerpo = await res.text();
+  if (!res.ok) throw new Error(`Meta no entregó la nota de voz (${res.status}): ${cuerpo.slice(0, 300)}`);
+  const j = JSON.parse(cuerpo) as { messages?: { id?: string }[] };
+  return j.messages?.[0]?.id ?? mediaId;
+}
+
+/** Traduce el error de Meta a algo que entienda quien atiende, no un JSON. */
+export function motivoEntendible(e: unknown): string {
+  const texto = e instanceof Error ? e.message : String(e);
+  if (/24|re-?engagement|outside.*window|131047/i.test(texto)) {
+    return "Pasaron más de 24 horas desde el último mensaje de la persona y WhatsApp ya no deja mandar audios. Escríbele un texto primero y espera su respuesta.";
+  }
+  if (/190|expired|invalid.*token|401/i.test(texto)) {
+    return "La llave de WhatsApp caducó. Hay que renovarla.";
+  }
+  if (/Falta configurar WhatsApp/i.test(texto)) return texto;
+  if (/network connection lost|connection.*(closed|reset)/i.test(texto)) {
+    return "Se cortó la conexión con WhatsApp al subir el audio. Vuelve a intentarlo.";
+  }
+  if (/rechazó el audio/i.test(texto)) {
+    return "WhatsApp no aceptó el formato del audio. Prueba a grabar desde el celular.";
+  }
+  return `No se pudo enviar la nota de voz. ${texto}`;
+}

--- a/src/media/oggOpus.ts
+++ b/src/media/oggOpus.ts
@@ -1,0 +1,255 @@
+/**
+ * DE WEBM A OGG — para que una nota de voz grabada en el navegador llegue a
+ * WhatsApp como NOTA DE VOZ de verdad, con su ondita, y no como un archivo.
+ *
+ * POR QUÉ HACE FALTA (11/08/2026, tras una tarde de intentos):
+ * WhatsApp solo trata como nota de voz el audio **Opus dentro de un OGG**.
+ * Chrome no sabe grabar eso: graba `audio/mp4` (que Meta acepta al subir y
+ * luego NO entrega, error 131053, y que el celular tampoco reproduce) o
+ * `audio/webm`, que WhatsApp ni acepta.
+ *
+ * La clave: **el `webm` de Chrome YA lleva Opus dentro**. Es el mismo sonido
+ * que quiere WhatsApp, solo que envuelto en otra caja. Aquí se cambia la caja,
+ * sin tocar ni recomprimir el audio — así que no se pierde calidad y no hace
+ * falta ningún conversor.
+ *
+ * Si algo no cuadra, TODAS las funciones devuelven null en vez de inventarse un
+ * archivo: quien llama manda entonces el original como adjunto. Un audio que se
+ * oye mal sería peor que un archivo que se abre aparte.
+ */
+
+// ── lectura de WebM (Matroska) ────────────────────────────────────────────────
+// Un WebM es un árbol de elementos: cada uno lleva su identificador y su
+// tamaño, ambos en longitud variable (el primer bit marcado dice cuántos bytes
+// ocupa). Solo se buscan tres cosas: la cabecera de Opus, la pista de audio y
+// los trozos de sonido.
+
+interface Lector {
+  datos: Uint8Array;
+  pos: number;
+}
+
+/** Lee un número de longitud variable. `conMarca` conserva el bit indicador
+ *  (los identificadores lo llevan; los tamaños, no). */
+function leerVint(l: Lector, conMarca: boolean): number | null {
+  if (l.pos >= l.datos.length) return null;
+  const primero = l.datos[l.pos];
+  if (primero === 0) return null;
+  let largo = 1;
+  while (largo <= 8 && !(primero & (0x80 >> (largo - 1)))) largo++;
+  if (largo > 8 || l.pos + largo > l.datos.length) return null;
+  let valor = conMarca ? primero : primero & (0xff >> largo);
+  for (let i = 1; i < largo; i++) valor = valor * 256 + l.datos[l.pos + i];
+  l.pos += largo;
+  return valor;
+}
+
+const ID_SEGMENT = 0x18538067;
+const ID_TRACKS = 0x1654ae6b;
+const ID_TRACK_ENTRY = 0xae;
+const ID_CODEC_PRIVATE = 0x63a2;
+const ID_CLUSTER = 0x1f43b675;
+const ID_SIMPLE_BLOCK = 0xa3;
+const ID_BLOCK_GROUP = 0xa0;
+const ID_BLOCK = 0xa1;
+
+// Los contenedores se recorren por dentro; el resto se salta entero.
+const CONTENEDORES = new Set([ID_SEGMENT, ID_TRACKS, ID_TRACK_ENTRY, ID_CLUSTER, ID_BLOCK_GROUP]);
+
+export interface AudioWebm {
+  /** La cabecera OpusHead que el propio navegador escribió. */
+  cabecera: Uint8Array;
+  /** Cada paquete de sonido, en orden. */
+  paquetes: Uint8Array[];
+}
+
+/** ¿Esto es un WebM? Empieza por la firma EBML `1A 45 DF A3`. */
+export function esWebm(bytes: ArrayBuffer): boolean {
+  const b = new Uint8Array(bytes, 0, Math.min(4, bytes.byteLength));
+  return b.length === 4 && b[0] === 0x1a && b[1] === 0x45 && b[2] === 0xdf && b[3] === 0xa3;
+}
+
+/** Saca de un WebM la cabecera de Opus y sus paquetes de sonido. */
+export function leerWebmOpus(bytes: ArrayBuffer): AudioWebm | null {
+  const datos = new Uint8Array(bytes);
+  if (!esWebm(bytes)) return null;
+
+  let cabecera: Uint8Array | null = null;
+  const paquetes: Uint8Array[] = [];
+
+  const recorrer = (desde: number, hasta: number): void => {
+    const l: Lector = { datos, pos: desde };
+    while (l.pos < hasta) {
+      const id = leerVint(l, true);
+      if (id === null) return;
+      const tam = leerVint(l, false);
+      if (tam === null) return;
+      const fin = Math.min(l.pos + tam, hasta);
+
+      if (id === ID_CODEC_PRIVATE) {
+        cabecera = datos.subarray(l.pos, fin);
+      } else if (id === ID_SIMPLE_BLOCK || id === ID_BLOCK) {
+        // número de pista (variable) + 2 bytes de tiempo + 1 de banderas
+        const b: Lector = { datos, pos: l.pos };
+        if (leerVint(b, false) !== null) {
+          const inicio = b.pos + 3;
+          if (inicio < fin) paquetes.push(datos.subarray(inicio, fin));
+        }
+      } else if (CONTENEDORES.has(id)) {
+        recorrer(l.pos, fin);
+      }
+      l.pos = fin;
+    }
+  };
+
+  recorrer(0, datos.length);
+  // La cabecera de Opus siempre empieza por "OpusHead"; sin ella no hay audio.
+  if (!cabecera || paquetes.length === 0) return null;
+  const c = cabecera as Uint8Array;
+  const firma = String.fromCharCode(...c.subarray(0, 8));
+  if (firma !== "OpusHead") return null;
+  return { cabecera: c, paquetes };
+}
+
+// ── escritura de OGG ──────────────────────────────────────────────────────────
+
+// CRC de las páginas OGG. No es el CRC32 de siempre: va sin invertir la
+// entrada ni la salida, y por eso se calcula a mano.
+const TABLA_CRC = (() => {
+  const t = new Uint32Array(256);
+  for (let i = 0; i < 256; i++) {
+    let r = i << 24;
+    for (let j = 0; j < 8; j++) r = r & 0x80000000 ? ((r << 1) ^ 0x04c11db7) >>> 0 : (r << 1) >>> 0;
+    t[i] = r >>> 0;
+  }
+  return t;
+})();
+
+function crcOgg(pagina: Uint8Array): number {
+  let crc = 0;
+  for (const b of pagina) crc = ((crc << 8) ^ TABLA_CRC[((crc >>> 24) ^ b) & 0xff]) >>> 0;
+  return crc >>> 0;
+}
+
+/**
+ * Cuántas muestras dura un paquete de Opus, leyendo su primer byte (el "TOC").
+ * Hace falta para que el reproductor enseñe bien la duración: sin esto, la
+ * nota de voz aparece con un tiempo inventado.
+ */
+export function muestrasDelPaquete(paquete: Uint8Array): number {
+  if (!paquete.length) return 0;
+  const toc = paquete[0];
+  const config = toc >> 3;
+  const ms =
+    config < 12
+      ? [10, 20, 40, 60][config % 4]
+      : config < 16
+        ? [10, 20][config % 2]
+        : [2.5, 5, 10, 20][config % 4];
+  // Todo se cuenta a 48 kHz, que es lo que exige OGG/Opus.
+  const marcos = (toc & 0x03) === 0 ? 1 : (toc & 0x03) === 3 ? (paquete[1] ?? 1) & 0x3f : 2;
+  return Math.round(ms * 48) * Math.max(1, marcos);
+}
+
+function pagina(
+  datos: Uint8Array[],
+  granulo: number,
+  serie: number,
+  secuencia: number,
+  tipo: number,
+): Uint8Array {
+  // Cada paquete se parte en tramos de 255 bytes: así lo describe la tabla.
+  const tramos: number[] = [];
+  for (const d of datos) {
+    let queda = d.length;
+    while (queda >= 255) {
+      tramos.push(255);
+      queda -= 255;
+    }
+    tramos.push(queda);
+  }
+  const cuerpo = datos.reduce((n, d) => n + d.length, 0);
+  const salida = new Uint8Array(27 + tramos.length + cuerpo);
+  const vista = new DataView(salida.buffer);
+
+  salida.set([0x4f, 0x67, 0x67, 0x53], 0); // "OggS"
+  salida[4] = 0; // versión
+  salida[5] = tipo; // 2 = primera página, 4 = última, 0 = normal
+  // El gránulo es de 64 bits; con notas de voz nunca pasa de 32, así que la
+  // parte alta va en cero.
+  vista.setUint32(6, granulo >>> 0, true);
+  vista.setUint32(10, 0, true);
+  vista.setUint32(14, serie, true);
+  vista.setUint32(18, secuencia, true);
+  vista.setUint32(22, 0, true); // el CRC se rellena al final
+  salida[26] = tramos.length;
+  salida.set(tramos, 27);
+  let off = 27 + tramos.length;
+  for (const d of datos) {
+    salida.set(d, off);
+    off += d.length;
+  }
+  vista.setUint32(22, crcOgg(salida), true);
+  return salida;
+}
+
+/**
+ * Convierte el WebM del navegador en un OGG/Opus que WhatsApp trata como nota
+ * de voz. Devuelve null si el archivo no es lo que esperamos.
+ *
+ * `serie` es el identificador del flujo; se puede fijar para que el resultado
+ * sea idéntico en cada corrida (las pruebas lo agradecen).
+ */
+export function webmOpusAOgg(bytes: ArrayBuffer, serie = 0x45434320): Uint8Array | null {
+  const leido = leerWebmOpus(bytes);
+  if (!leido) return null;
+
+  const paginas: Uint8Array[] = [];
+  let secuencia = 0;
+
+  // 1) La cabecera, sola en su página (así lo pide el formato).
+  paginas.push(pagina([leido.cabecera], 0, serie, secuencia++, 2));
+
+  // 2) Los "comentarios": obligatorios aunque vayan vacíos.
+  const etiquetas = new TextEncoder().encode("OpusTags");
+  const proveedor = new TextEncoder().encode("Escuela Con Confianza");
+  const tags = new Uint8Array(8 + 4 + proveedor.length + 4);
+  tags.set(etiquetas, 0);
+  new DataView(tags.buffer).setUint32(8, proveedor.length, true);
+  tags.set(proveedor, 12);
+  new DataView(tags.buffer).setUint32(12 + proveedor.length, 0, true);
+  paginas.push(pagina([tags], 0, serie, secuencia++, 0));
+
+  // 3) El sonido. Se agrupan paquetes por página (tope de 255 tramos) y el
+  //    gránulo acumula las muestras, que es como el reproductor sabe la
+  //    duración y puede moverse por el audio.
+  let granulo = 0;
+  let grupo: Uint8Array[] = [];
+  let tramosDelGrupo = 0;
+  const cerrarGrupo = (ultima: boolean) => {
+    if (!grupo.length) return;
+    paginas.push(pagina(grupo, granulo, serie, secuencia++, ultima ? 4 : 0));
+    grupo = [];
+    tramosDelGrupo = 0;
+  };
+
+  for (let i = 0; i < leido.paquetes.length; i++) {
+    const p = leido.paquetes[i];
+    const tramos = Math.floor(p.length / 255) + 1;
+    if (tramosDelGrupo + tramos > 255) cerrarGrupo(false);
+    grupo.push(p);
+    tramosDelGrupo += tramos;
+    granulo += muestrasDelPaquete(p);
+    if (i === leido.paquetes.length - 1) cerrarGrupo(true);
+  }
+  if (grupo.length) cerrarGrupo(true);
+
+  const total = paginas.reduce((n, p) => n + p.length, 0);
+  const salida = new Uint8Array(total);
+  let off = 0;
+  for (const p of paginas) {
+    salida.set(p, off);
+    off += p.length;
+  }
+  return salida;
+}

--- a/test/nota-de-voz.test.ts
+++ b/test/nota-de-voz.test.ts
@@ -1,0 +1,173 @@
+/**
+ * NOTAS DE VOZ DEL EQUIPO.
+ *
+ * Lo que se protege aquí, por orden de gravedad:
+ *  1. Que el audio salga en el formato que WhatsApp SÍ entrega. Es donde está
+ *     todo el problema: Meta acepta la subida y el envío de un archivo que
+ *     después no puede procesar, y el fallo aparece más tarde y en otro sitio.
+ *  2. Que no se le mande la voz de alguien a un número que no existe.
+ *  3. Que los errores de Meta se traduzcan a algo que entienda quien atiende.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  FORMATOS_WHATSAPP,
+  cuerpoMultipart,
+  enviarNotaDeVoz,
+  formatoAceptado,
+  formatoGrabable,
+  motivoEntendible,
+  mp4EsFragmentado,
+  telefonoDe,
+  tipoBase,
+  vaComoNotaDeVoz,
+} from "../src/media/notaDeVoz";
+
+const env = {
+  WHATSAPP_PHONE_NUMBER_ID: "123456",
+  WHATSAPP_ACCESS_TOKEN: "EAA-token",
+} as any;
+
+/** Cabecera real del MP4 que graba Chrome, con su caja `moof` de fragmento. */
+function mp4Fragmentado(): ArrayBuffer {
+  return new TextEncoder().encode(
+    "\0\0\0\x24ftypisom\0\0\x02\0isomiso6iso2vp09mp41\0\0\x02]moov" + "x".repeat(40) + "\0\0\0\x10moof",
+  ).buffer as ArrayBuffer;
+}
+/** Un .m4a de toda la vida: mismo principio, sin fragmentos. */
+function mp4Normal(): ArrayBuffer {
+  return new TextEncoder().encode("\0\0\0\x20ftypM4A \0\0\0\0M4A mp42isom\0\0\x02]moov" + "x".repeat(60))
+    .buffer as ArrayBuffer;
+}
+
+describe("qué formatos entran y cuáles no", () => {
+  it("acepta los de WhatsApp aunque lleven el códec pegado", () => {
+    expect(formatoAceptado("audio/ogg;codecs=opus")).toBe(true);
+    expect(tipoBase("audio/ogg;codecs=opus")).toBe("audio/ogg");
+    for (const f of FORMATOS_WHATSAPP) expect(formatoAceptado(f)).toBe(true);
+  });
+
+  it("el webm de Chrome se acepta en el panel aunque WhatsApp no lo admita", () => {
+    // WhatsApp no admite webm, pero lleva Opus dentro y el worker le cambia la
+    // caja. Si esto se cerrara, en Chrome no se podría grabar nada servible.
+    expect(formatoAceptado("audio/webm")).toBe(false);
+    expect(formatoGrabable("audio/webm;codecs=opus")).toBe(true);
+    expect(formatoGrabable("audio/flac")).toBe(false);
+  });
+});
+
+describe("el MP4 de Chrome frente al de una grabadora", () => {
+  it("el de Chrome lleva caja moof y el normal no", () => {
+    expect(mp4EsFragmentado(mp4Fragmentado())).toBe(true);
+    expect(mp4EsFragmentado(mp4Normal())).toBe(false);
+  });
+
+  it("solo el que WhatsApp puede procesar va como nota de voz", () => {
+    expect(vaComoNotaDeVoz("audio/mp4", mp4Fragmentado())).toBe(false);
+    expect(vaComoNotaDeVoz("audio/mp4", mp4Normal())).toBe(true);
+    expect(vaComoNotaDeVoz("audio/ogg", new ArrayBuffer(8))).toBe(true);
+  });
+});
+
+describe("a quién se le puede mandar", () => {
+  it("acepta un teléfono normal", () => {
+    expect(telefonoDe("51992117242")).toBe("51992117242");
+    expect(telefonoDe("+51 992 117 242")).toBe("51992117242");
+  });
+
+  it("rechaza los identificadores que NO son teléfonos", () => {
+    // Hay proveedores que identifican al contacto con algo así; quitarle las
+    // letras daría un número de 16 cifras que no existe.
+    expect(telefonoDe("PE.1618339096292670")).toBeNull();
+    expect(telefonoDe("1618339096292670")).toBeNull();
+    expect(telefonoDe("12345")).toBeNull();
+  });
+});
+
+describe("el cuerpo del archivo se arma a mano", () => {
+  const { cuerpo, contentType } = cuerpoMultipart(
+    new Uint8Array([1, 2, 3, 4, 5]).buffer as ArrayBuffer,
+    "audio/ogg",
+    "nota-de-voz.ogg",
+  );
+  const texto = new TextDecoder().decode(cuerpo);
+
+  it("declara la frontera y lleva las tres partes que pide Meta", () => {
+    const frontera = contentType.split("boundary=")[1];
+    expect(contentType).toMatch(/^multipart\/form-data; boundary=/);
+    expect(texto).toContain('name="messaging_product"');
+    expect(texto).toContain('name="file"; filename="nota-de-voz.ogg"');
+    expect(texto.endsWith(`--${frontera}--\r\n`)).toBe(true);
+  });
+
+  it("los bytes del audio viajan intactos", () => {
+    const marca = cuerpo.indexOf(1);
+    expect([...cuerpo.slice(marca, marca + 5)]).toEqual([1, 2, 3, 4, 5]);
+  });
+});
+
+describe("el envío", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  function metaResponde() {
+    const llamadas: { url: string; body: unknown }[] = [];
+    vi.stubGlobal("fetch", async (url: string, init: any) => {
+      llamadas.push({ url: String(url), body: init?.body });
+      if (String(url).endsWith("/media")) {
+        return new Response(JSON.stringify({ id: "media-99" }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ messages: [{ id: "wamid.1" }] }), { status: 200 });
+    });
+    return llamadas;
+  }
+
+  it("sube el audio y lo manda como nota de voz", async () => {
+    const llamadas = metaResponde();
+    const id = await enviarNotaDeVoz(env, "51992117242", new ArrayBuffer(64), "audio/ogg;codecs=opus");
+    expect(id).toBe("wamid.1");
+    expect(llamadas[0].url).toContain("/123456/media");
+    const enviado = JSON.parse(String(llamadas[llamadas.length - 1].body));
+    expect(enviado).toMatchObject({ to: "51992117242", type: "audio", audio: { id: "media-99" } });
+  });
+
+  it("el MP4 fragmentado va como adjunto en vez de perderse", async () => {
+    // Mandarlo como audio acaba en un 131053 que aparece tarde y deja a la
+    // persona sin nada. Como documento sí llega: WhatsApp no lo procesa.
+    const llamadas = metaResponde();
+    await enviarNotaDeVoz(env, "51992117242", mp4Fragmentado(), "audio/mp4");
+    const enviado = JSON.parse(String(llamadas[llamadas.length - 1].body));
+    expect(enviado.type).toBe("document");
+    expect(enviado.document).toMatchObject({ id: "media-99", filename: "Nota de voz.m4a" });
+  });
+
+  it("si Meta rechaza la subida, NO se manda ningún mensaje", async () => {
+    const urls: string[] = [];
+    vi.stubGlobal("fetch", async (url: string) => {
+      urls.push(String(url));
+      return new Response('{"error":{"message":"nope"}}', { status: 400 });
+    });
+    await expect(
+      enviarNotaDeVoz(env, "51992117242", new ArrayBuffer(8), "audio/ogg"),
+    ).rejects.toThrow(/rechazó el audio/i);
+    expect(urls.filter((u) => u.includes("/messages"))).toHaveLength(0);
+  });
+
+  it("sin llaves de WhatsApp avisa en claro", async () => {
+    await expect(
+      enviarNotaDeVoz({} as any, "51992117242", new ArrayBuffer(8), "audio/ogg"),
+    ).rejects.toThrow(/Falta configurar WhatsApp/);
+  });
+});
+
+describe("los errores se traducen", () => {
+  it("la ventana de 24 horas se explica sin tecnicismos", () => {
+    const msg = motivoEntendible(new Error("(400): (#131047) Re-engagement message"));
+    expect(msg).toMatch(/24 horas/);
+    expect(msg).not.toMatch(/131047/);
+  });
+
+  it("una llave caducada se nombra como tal", () => {
+    expect(motivoEntendible(new Error("(401) Error validating access token: expired"))).toMatch(
+      /llave de WhatsApp caducó/i,
+    );
+  });
+});

--- a/test/ogg-opus.test.ts
+++ b/test/ogg-opus.test.ts
@@ -1,0 +1,129 @@
+/**
+ * DE WEBM A OGG — que la nota de voz llegue como NOTA DE VOZ, no como archivo.
+ *
+ * Historia (11/08/2026): Chrome graba `audio/mp4` "por trozos". Meta lo acepta
+ * al subir, no lo entrega (error 131053) y, mandado como adjunto, el celular
+ * tampoco lo reproduce. Pero el `webm` de Chrome ya lleva Opus dentro, que es
+ * exactamente lo que WhatsApp quiere: solo hay que cambiarle la caja.
+ *
+ * Aquí se comprueba que la caja nueva está bien construida, porque un OGG mal
+ * armado se oiría cortado o no se oiría — y eso sería peor que un archivo.
+ */
+import { describe, it, expect } from "vitest";
+import { esWebm, leerWebmOpus, muestrasDelPaquete, webmOpusAOgg } from "../src/media/oggOpus";
+
+// ── un WebM mínimo, escrito a mano ────────────────────────────────────────────
+
+function vint(n: number): number[] {
+  // Tamaños de hasta 2 bytes, suficiente para las pruebas.
+  return n < 0x7f ? [0x80 | n] : [0x40 | (n >> 8), n & 0xff];
+}
+function elemento(id: number[], carga: number[]): number[] {
+  return [...id, ...vint(carga.length), ...carga];
+}
+const OPUS_HEAD = [...new TextEncoder().encode("OpusHead"), 1, 1, 0x38, 0x01, 0x80, 0xbb, 0, 0, 0, 0, 0];
+
+/** Un paquete de Opus de 20 ms: el primer byte manda (config 1, un marco). */
+function paqueteOpus(relleno: number, largo = 40): number[] {
+  return [0x08, ...Array(largo - 1).fill(relleno)];
+}
+
+function webmDePrueba(paquetes: number[][]): ArrayBuffer {
+  const codecPrivate = elemento([0x63, 0xa2], OPUS_HEAD);
+  const trackEntry = elemento([0xae], codecPrivate);
+  const tracks = elemento([0x16, 0x54, 0xae, 0x6b], trackEntry);
+  const bloques = paquetes.flatMap((p) =>
+    // pista 1 + 2 bytes de tiempo + 1 de banderas + el paquete
+    elemento([0xa3], [0x81, 0x00, 0x00, 0x00, ...p]),
+  );
+  const cluster = elemento([0x1f, 0x43, 0xb6, 0x75], bloques);
+  const segment = elemento([0x18, 0x53, 0x80, 0x67], [...tracks, ...cluster]);
+  const cabeceraEbml = [0x1a, 0x45, 0xdf, 0xa3, 0x84, 0x01, 0x02, 0x03, 0x04];
+  return new Uint8Array([...cabeceraEbml, ...segment]).buffer;
+}
+
+describe("leer el webm del navegador", () => {
+  it("reconoce un webm por su firma", () => {
+    expect(esWebm(webmDePrueba([paqueteOpus(1)]))).toBe(true);
+    expect(esWebm(new Uint8Array([0, 0, 0, 0x24, 0x66, 0x74, 0x79, 0x70]).buffer)).toBe(false);
+  });
+
+  it("saca la cabecera de Opus y los paquetes de sonido", () => {
+    const leido = leerWebmOpus(webmDePrueba([paqueteOpus(1), paqueteOpus(2), paqueteOpus(3)]));
+    expect(leido).not.toBeNull();
+    expect(String.fromCharCode(...leido!.cabecera.subarray(0, 8))).toBe("OpusHead");
+    expect(leido!.paquetes).toHaveLength(3);
+    expect(leido!.paquetes[1][1]).toBe(2);
+  });
+
+  it("ante un archivo que no es webm devuelve null en vez de inventarse algo", () => {
+    expect(leerWebmOpus(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]).buffer)).toBeNull();
+    expect(webmOpusAOgg(new Uint8Array([1, 2, 3, 4]).buffer)).toBeNull();
+  });
+});
+
+describe("la duración de cada paquete", () => {
+  it("un paquete de 20 ms son 960 muestras a 48 kHz", () => {
+    // Sin esto el reproductor enseña una duración inventada.
+    expect(muestrasDelPaquete(new Uint8Array([0x08]))).toBe(960);
+  });
+
+  it("un paquete vacío no revienta", () => {
+    expect(muestrasDelPaquete(new Uint8Array([]))).toBe(0);
+  });
+});
+
+describe("el ogg que se manda a WhatsApp", () => {
+  const ogg = webmOpusAOgg(webmDePrueba([paqueteOpus(1), paqueteOpus(2), paqueteOpus(3)]))!;
+
+  it("se genera", () => {
+    expect(ogg).toBeInstanceOf(Uint8Array);
+    expect(ogg.length).toBeGreaterThan(60);
+  });
+
+  it("empieza por OggS y trae la cabecera y los comentarios", () => {
+    const texto = new TextDecoder("latin1").decode(ogg);
+    expect(texto.startsWith("OggS")).toBe(true);
+    expect(texto).toContain("OpusHead");
+    expect(texto).toContain("OpusTags");
+  });
+
+  it("la primera página se marca como principio de flujo", () => {
+    expect(ogg[5]).toBe(2); // bandera de "primera página"
+  });
+
+  it("la última página se marca como final", () => {
+    // Sin esta marca, algunos reproductores creen que el audio sigue.
+    const texto = new TextDecoder("latin1").decode(ogg);
+    const ultima = texto.lastIndexOf("OggS");
+    expect(ogg[ultima + 5]).toBe(4);
+  });
+
+  it("el gránulo acumula la duración de los tres paquetes", () => {
+    const texto = new TextDecoder("latin1").decode(ogg);
+    const ultima = texto.lastIndexOf("OggS");
+    const granulo = new DataView(ogg.buffer, ogg.byteOffset + ultima + 6, 4).getUint32(0, true);
+    expect(granulo).toBe(960 * 3);
+  });
+
+  it("cada página lleva su CRC calculado, no en cero", () => {
+    // El CRC de OGG no es el CRC32 normal; si se calcula mal, el reproductor
+    // descarta la página entera y el audio llega mudo.
+    const texto = new TextDecoder("latin1").decode(ogg);
+    let i = -1;
+    let paginas = 0;
+    while ((i = texto.indexOf("OggS", i + 1)) !== -1) {
+      const crc = new DataView(ogg.buffer, ogg.byteOffset + i + 22, 4).getUint32(0, true);
+      expect(crc).not.toBe(0);
+      paginas++;
+    }
+    expect(paginas).toBe(3); // cabecera + comentarios + sonido
+  });
+
+  it("el sonido viaja intacto, sin recomprimir", () => {
+    const texto = new TextDecoder("latin1").decode(ogg);
+    // El relleno de cada paquete de prueba tiene que seguir ahí.
+    expect(texto).toContain(String.fromCharCode(1).repeat(39));
+    expect(texto).toContain(String.fromCharCode(3).repeat(39));
+  });
+});


### PR DESCRIPTION
## Qué es

Un botón de micrófono en el compositor. En mitad de una conversación con el bot, alguien del equipo graba diez segundos con su voz y los manda. Quien está del otro lado deja de hablarle a un sistema y **oye a una persona**. Después el bot sigue.

Al tocar el micrófono, una barra ocupa el sitio del cuadro de escribir con los controles que la gente ya conoce de WhatsApp: **papelera, pausa / seguir, el tiempo corriendo y enviar**. Al enviar, el bot queda **pausado** en ese chat, igual que al responder por escrito.

## Por qué esto vende

La objeción de siempre con un bot es *"¿hay alguien ahí?"*. Un mensaje escrito no la resuelve: también lo escribe el bot. Una nota de voz sí, y llega justo donde más se cae una venta — la duda, la queja, el caso delicado. Se usa **en el momento preciso** y se devuelve la conversación al bot.

## El formato es TODO el problema, y no es evidente

WhatsApp solo trata como nota de voz el audio **Opus dentro de un OGG**. Y el navegador no sabe grabar eso:

| Lo que graba el navegador | Qué pasa |
|---|---|
| `audio/mp4` (Chrome) | Meta lo acepta al subir, **no lo entrega**, y el celular tampoco lo reproduce |
| `audio/webm` (Chrome) | WhatsApp ni lo admite |
| `audio/ogg` | Solo lo graba Firefox |

**La clave: el webm de Chrome YA lleva Opus dentro.** Es exactamente el sonido que quiere WhatsApp, solo que en otra caja.

`src/media/oggOpus.ts` le cambia la caja: lee los paquetes del WebM (Matroska) y los escribe en páginas OGG. Sin recomprimir, sin pérdida, **sin una sola dependencia** — ~200 líneas de TypeScript que corren dentro del Worker, donde no hay ffmpeg ni lo va a haber.

Detalles que costaron encontrarlos y están anotados en el código: el **CRC de OGG no es el CRC32 de siempre** (va sin invertir la entrada ni la salida), hay que **acumular el gránulo** o el reproductor enseña una duración inventada, y la última página lleva su marca de fin.

**Verificado contra un decodificador real**, no solo con mis propias pruebas: generé un webm/opus con ffmpeg, lo convertí con este mismo código, y `ffprobe` lee el resultado como `ogg/opus, 48 kHz, mono` con la duración exacta del original, y decodifica a un wav con sonido.

## Tres trampas de Meta que quedan documentadas

1. **Meta acepta la subida Y el envío** —devuelve su `wamid`— de un audio que después no puede procesar. El fallo llega más tarde y por otro sitio, en el webhook de estados: `131053 … uploaded with mimetype as audio/mp4, however on processing it is of type application/octet-stream`. Mientras tanto, en el panel figura como enviado.
2. **Preguntarle `GET /<media_id>` qué tipo recibió NO sirve**: devuelve el mime que le declaraste tú, no el que detecta. Probado y descartado. Lo que sí distingue el archivo es su estructura: los MP4 de `MediaRecorder` llevan cajas `moof`.
3. **Con `FormData`** el cuerpo puede irse en *chunked* y la subida morir con un `Network connection lost` que parece un problema de red y no lo es. El multipart se arma a mano, en un bloque.

Cuando el archivo no es de los que WhatsApp procesa, **se manda como documento** en vez de perderse: llega igual, aunque sin la ondita.

## Reglas que sigue

- **Primero se envía, después se guarda.** Si WhatsApp lo rechaza, en el hilo no queda un audio que la persona nunca escuchó (misma regla que `/reply`).
- **Enviar una nota de voz pausa el bot.** Se graba justo para demostrar que hay alguien atendiendo; que el bot conteste encima lo desmiente.
- **No se manda a un contacto cuyo identificador no sea un teléfono** (8–15 dígitos, sin letras). Hay proveedores que identifican al contacto con otra cosa, y ahí quitarle las letras daría un número que no existe. Antes que mandar la voz de alguien a un número equivocado, no se manda.
- **Los errores se traducen**: la ventana de 24 horas y la llave caducada se explican en una frase, no con un JSON de Graph.

## Alcance

Aditivo. Sin `WHATSAPP_PHONE_NUMBER_ID` y `WHATSAPP_ACCESS_TOKEN`, el botón avisa y no rompe nada. No toca el comportamiento del bot ni ninguna ruta existente.

Queda fuera a propósito, para no mezclar temas: guardar una copia del audio en R2 para volver a escucharlo dentro del panel. Es el siguiente paso natural.

**463 pruebas en verde** (26 nuevas) y `tsc` limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added voice-note recording to the admin conversation composer.
  - Recordings can be paused, resumed, discarded, or sent directly from the conversation view.
  - Audio notes are validated, converted when necessary, and delivered through WhatsApp.
  - Added clear feedback for unsupported formats, oversized files, microphone access issues, and delivery failures.
- **Tests**
  - Added coverage for audio recording, conversion, validation, upload, delivery, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->