### PR TITLE
fix(admin): cargar Tailwind desde un CDN de producción (jsDelivr v4) en vez del Play CDN

### DIFF
--- a/src/admin/views/layout.ts
+++ b/src/admin/views/layout.ts
@@ -63,42 +63,43 @@ const NAV: Section[] = [
   },
 ];
 
-// <head> assets: fonts, Tailwind CDN + token config, lucide, htmx.
+// <head> assets: fonts, Tailwind (browser build) + token theme, lucide, htmx.
+// Tailwind se carga con el build oficial en-navegador de v4 (@tailwindcss/browser)
+// servido por jsDelivr, en lugar del antiguo Play CDN `cdn.tailwindcss.com`.
+// Motivo: el Play CDN es solo para desarrollo (no soportado en producción por
+// Tailwind) y es un único punto de fallo externo — si ese dominio se cae o queda
+// bloqueado, el panel se queda SIN ninguna utilidad de layout y colapsa a una
+// columna para todos los bots. jsDelivr es un CDN de producción con failover y la
+// versión queda fijada (@4). El antiguo `tailwind.config` de v3 se migra al bloque
+// `@theme` de v4 (mismos tokens de color/tipografía).
 const HEAD_ASSETS = `
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
   <script src="https://unpkg.com/htmx.org@2.0.4"></script>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script>
-    tailwind.config = {
-      theme: {
-        extend: {
-          colors: {
-            bg: "#141009",
-            panel: "#1d1710",
-            panel2: "#241c13",
-            raise: "#2b2116",
-            line: "#352a1d",
-            linelit: "#4c3a26",
-            accent: { DEFAULT: "#f07a3f", soft: "rgba(240,122,63,.14)" },
-            accent2: "#f5a623",
-            cream: "#efe7da",
-            muted: "#a1907b",
-            dim: "#726555",
-            ok: "#7fb77e",
-            info: "#7aa2d6",
-            bad: "#d97a6a",
-            violet: "#b99bd6",
-          },
-          fontFamily: {
-            display: ["'Space Grotesk'", "ui-sans-serif", "system-ui", "sans-serif"],
-            mono: ["'JetBrains Mono'", "ui-monospace", "monospace"],
-          },
-        },
-      },
-    };
-  </script>
+  <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+  <style type="text/tailwindcss">
+    @theme {
+      --color-bg: #141009;
+      --color-panel: #1d1710;
+      --color-panel2: #241c13;
+      --color-raise: #2b2116;
+      --color-line: #352a1d;
+      --color-linelit: #4c3a26;
+      --color-accent: #f07a3f;
+      --color-accent-soft: rgba(240,122,63,.14);
+      --color-accent2: #f5a623;
+      --color-cream: #efe7da;
+      --color-muted: #a1907b;
+      --color-dim: #726555;
+      --color-ok: #7fb77e;
+      --color-info: #7aa2d6;
+      --color-bad: #d97a6a;
+      --color-violet: #b99bd6;
+      --font-display: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+      --font-mono: "JetBrains Mono", ui-monospace, monospace;
+    }
+  </style>
   <script src="https://unpkg.com/lucide@latest"></script>`;
 
 // Global stylesheet: design tokens, base type/scroll, the reusable component


### PR DESCRIPTION
## Problema

El panel `/admin` carga Tailwind desde **`cdn.tailwindcss.com`** (el **Play CDN v3**) en `src/admin/views/layout.ts`.

Dos problemas con eso en producción:

1. **Tailwind marca ese CDN como "solo desarrollo, no producción"** (lo dice su propia doc del Play CDN).
2. **Es un único punto de fallo externo.** El panel no tiene CSS de respaldo: todas las grillas y flex usan utilidades de Tailwind. Si `cdn.tailwindcss.com` se cae, queda bloqueado (red corporativa / país) o tiene una incidencia, el panel de **todos los bots** se queda sin utilidades y **colapsa a una sola columna**, ilegible.

Esto no es hipotético: le pasó a un bot real en producción. El panel quedó roto hasta que el CDN volvió. Como el archivo es idéntico para todas las instalaciones, cualquier bot corre el mismo riesgo cuando el CDN falle.

## Cambio

Cargar el **build oficial en-navegador de Tailwind v4** (`@tailwindcss/browser@4`) desde **jsDelivr**, en lugar del Play CDN:

- `@tailwindcss/browser` es el **sucesor oficial** del Play CDN para v4.
- **jsDelivr** es un CDN de producción con **failover multi-proveedor** y la versión queda **fijada** (`@4`), no flotante.
- El antiguo `tailwind.config` de v3 se migra al bloque **`@theme` de v4** con los **mismos tokens** de color y tipografía → el aspecto del panel no cambia.

Un solo archivo, sin tocar lógica.

## Verificación

Este mismo cambio (misma URL de jsDelivr + mismos tokens `@theme`) ya está desplegado en un bot real: las utilidades del panel (`flex`, `grid-cols-2`, `bg-panel`, `bg-accent`, tipografías) renderizan correctamente en un navegador limpio.

> Nota para el/la mantenedor(a): al pasar de v3 a v4 conviene una pasada visual por el panel completo, por si alguna utilidad puntual cambió de nombre entre versiones (la migración de tokens de color/fuente sí está cubierta). Una alternativa aún más robusta —fuera del alcance de este PR, "empieza chico"— sería **precompilar Tailwind a CSS estático servido por el propio worker**, eliminando por completo la dependencia de un CDN externo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the admin interface to use Tailwind CSS v4’s browser build.
  * Preserved the existing visual theme, including color and font settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->