### PR TITLE
El campo de Configuración que borra el cerebro del bot sin avisar

### DIFF
--- a/src/admin/views/config.ts
+++ b/src/admin/views/config.ts
@@ -236,7 +236,8 @@ export function renderConfig(
             ? "✍ Modo manual: su bot está usando este texto como prompt completo, en lugar del automático. Para verlo entero o volver al automático: Mi Agente → Flujo → Agente."
             : "⚠️ Lo que escriba aquí REEMPLAZA el prompt completo del bot — incluida la información del negocio de arriba, su base de conocimiento y sus reglas de seguridad. No agrega instrucciones: las sustituye. Déjelo vacío para usar el prompt automático. Para editar sobre el prompt real, vaya a Mi Agente → Flujo → Agente.",
           value: settings[SETTING_KEYS.systemPromptOverride] ?? "",
-          placeholder: "Vacío = el bot arma su prompt solo con la información del negocio.",
+          placeholder:
+            "Vacío = el bot usa su prompt automático completo: la información del negocio, su base de conocimiento y sus reglas de seguridad.",
           rows: 4,
         })}
 

--- a/src/admin/views/config.ts
+++ b/src/admin/views/config.ts
@@ -180,6 +180,12 @@ export function renderConfig(
 ): string {
   const cardGroups = CONTROL_LIST.map((c) => renderCardGroup(c, settings)).join("");
 
+  // Este campo escribe la MISMA llave que "Prompt del agente" de Mi Agente →
+  // Flujo, donde el textarea viene precargado con el prompt efectivo. Aquí llega
+  // vacío, así que hay que decir de frente que lo que se escriba sustituye al
+  // prompt completo — no se suma a él.
+  const hasPromptOverride = (settings[SETTING_KEYS.systemPromptOverride] ?? "").trim() !== "";
+
   const savedBanner = saved
     ? `<div style="border:1px solid var(--ok);background:rgba(127,183,126,.1);color:var(--ok);padding:10px 14px;font-size:12.5px;font-weight:600">Guardado ✓</div>`
     : "";
@@ -225,10 +231,12 @@ export function renderConfig(
 
         ${renderTextArea({
           name: SETTING_KEYS.systemPromptOverride,
-          label: "Instrucciones personalizadas",
-          help: "Personalidad o reglas especiales. Déjalo vacío para usar la configuración automática.",
+          label: "Prompt del agente (avanzado)",
+          help: hasPromptOverride
+            ? "✍ Modo manual: su bot está usando este texto como prompt completo, en lugar del automático. Para verlo entero o volver al automático: Mi Agente → Flujo → Agente."
+            : "⚠️ Lo que escriba aquí REEMPLAZA el prompt completo del bot — incluida la información del negocio de arriba, su base de conocimiento y sus reglas de seguridad. No agrega instrucciones: las sustituye. Déjelo vacío para usar el prompt automático. Para editar sobre el prompt real, vaya a Mi Agente → Flujo → Agente.",
           value: settings[SETTING_KEYS.systemPromptOverride] ?? "",
-          placeholder: "Ej. Siempre ofrece agendar una cita al final.",
+          placeholder: "Vacío = el bot arma su prompt solo con la información del negocio.",
           rows: 4,
         })}
 

--- a/test/admin/routes.test.ts
+++ b/test/admin/routes.test.ts
@@ -125,6 +125,33 @@ describe("admin routes — navigation", () => {
     expect(await res.text()).toContain("Test Biz");
   });
 
+  // El campo escribe system_prompt_override: lo que se escriba ahí sustituye al
+  // prompt completo. Con la etiqueta anterior ("Instrucciones personalizadas")
+  // y su ejemplo de una sola regla, era razonable creer que se sumaba.
+  it("warns that the prompt field replaces the whole prompt when it is empty", async () => {
+    const res = await adminApp.fetch(req("/config", { headers: authHeaders }), makeEnv());
+    const html = await res.text();
+    expect(html).toContain("REEMPLAZA el prompt completo");
+    expect(html).toContain("Mi Agente → Flujo");
+    // El ejemplo viejo invitaba justo al error que este aviso evita.
+    expect(html).not.toContain("Ej. Siempre ofrece agendar una cita al final.");
+  });
+
+  it("shows manual mode when a prompt override is already saved", async () => {
+    const env = makeEnv(
+      makeStubDb([
+        {
+          frag: "SELECT key, value FROM settings",
+          all: [{ key: SETTING_KEYS.systemPromptOverride, value: "Responde siempre en verso." }],
+        },
+      ]),
+    );
+    const res = await adminApp.fetch(req("/config", { headers: authHeaders }), env);
+    const html = await res.text();
+    expect(html).toContain("Modo manual");
+    expect(html).toContain("Responde siempre en verso.");
+  });
+
   it("exports leads as CSV", async () => {
     const res = await adminApp.fetch(req("/leads/export.csv", { headers: authHeaders }), makeEnv());
     expect(res.status).toBe(200);


### PR DESCRIPTION
## Qué problema resuelve

En **Configuración** hay un campo llamado *"Instrucciones personalizadas — Personalidad o
reglas especiales"*, con el ejemplo *"Ej. Siempre ofrece agendar una cita al final."*. Todo
en él dice que **suma** una regla.

Escribe `system_prompt_override`: **reemplaza el prompt completo**. En cuanto guardas, el bot
pierde de golpe la información del negocio, las instrucciones de cuándo consultar su base de
conocimiento, el playbook del giro y el blindaje. Y lo peor: **sigue contestando**, así que no
hay señal de que algo se rompió.

En un bot real me dejó al asistente con 1,650 caracteres de reglas de estilo como único
cerebro —sin los 16,258 de contexto del negocio— durante casi una hora, **con campañas de
Google Ads corriendo**. Le ofreció a prospectos pagados una carrera presencial que la
universidad ya había cancelado por escrito. Estuve buscando el problema en la base de
conocimiento; la base nunca tuvo nada malo.

## Por qué es fácil caer

El campo llega **vacío**, así que uno escribe una sola frase y guarda. Nada en la pantalla
dice qué se pierde, y el único texto de ayuda —*"Déjalo vacío para usar la configuración
automática"*— se lee como "vacío = automático, con texto = automático + mi regla".

El rediseño del nodo **Mi Agente → Flujo → Agente** ya resolvió esto **para esa pantalla**:
precarga el prompt efectivo completo, marca `✍ manual` / `⚙ automático` y ofrece "Volver al
automático". Ahí editar es seguro, porque estás editando sobre el texto real.

Los dos campos escriben la **misma llave**, pero solo uno enseña lo que está en juego. El de
Configuración quedó como la puerta de atrás a la misma función, sin ninguna de las
protecciones.

## Qué cambia

Solo el texto y el estado de ese campo en `src/admin/views/config.ts`. Sin cambios de
comportamiento, de rutas ni de datos:

1. **Etiqueta**: "Instrucciones personalizadas" → **"Prompt del agente (avanzado)"**, para que
   nombre lo que de verdad hace y coincida con la del flujo.
2. **Ayuda cuando está vacío**: advierte que **reemplaza el prompt completo** —incluida la
   información del negocio y la base de conocimiento— y manda a Mi Agente → Flujo → Agente
   para editar sobre el prompt real.
3. **Ayuda cuando ya hay override**: avisa que el bot está en **modo manual** y dice dónde
   volver al automático (el reset ya existe en el flujo; aquí solo se señala).
4. **Placeholder**: se quita *"Ej. Siempre ofrece agendar una cita al final."* — era
   exactamente la invitación al error.

## Pruebas

Dos casos nuevos en `test/admin/routes.test.ts`: que la advertencia y la referencia al flujo
salen cuando el campo está vacío (y que el ejemplo viejo ya no aparece), y que con un override
guardado la pantalla dice "Modo manual" y muestra el texto vigente.

**Comprobado que fallan sin el parche** (`expected … to contain 'REEMPLAZA el prompt completo'`
y `… 'Modo manual'`) y pasan con él.

- `pnpm typecheck` — limpio
- `pnpm test` — **439 pruebas en verde, 65 archivos**

## Una alternativa, por si la prefieren

El arreglo de fondo sería **quitar el campo de Configuración** y dejar ahí solo un enlace a
Mi Agente → Flujo → Agente, que ya hace el trabajo bien y con red de seguridad. Dos campos
que escriben la misma llave con dos experiencias distintas van a seguir confundiendo.

No lo hice porque es una decisión de producto, no un bug, y el PR quería ser de un solo tema.
Si les parece, lo cambio en este mismo PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated advanced prompt guidance to clearly distinguish automatic, replacement, and manual editing modes.
  * Added directions for fully editing or reverting the prompt through the agent workflow settings.
  * Existing prompt overrides now display their saved text and indicate manual mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->