### PR TITLE
Fix: /webhooks/manychat no valida el header X-Api-Key que la guía promete como protección

### DIFF
--- a/skill/references/channel-setup-guides/manychat-webhook.md
+++ b/skill/references/channel-setup-guides/manychat-webhook.md
@@ -33,7 +33,7 @@ Al terminar esta guía, cuando un cliente te escriba por Instagram (o Messenger,
    ```
    Cuando te lo pida, pega la API Key y dale Enter.
 
-> Esta misma llave la vas a usar más abajo como un encabezado (`X-Api-Key`) para que tu bot confirme que el mensaje viene de TU ManyChat y no de un desconocido.
+> Esta misma llave la vas a usar más abajo como un encabezado (`X-Api-Key`) para que tu bot confirme que el mensaje viene de TU ManyChat y no de un desconocido. Para que tu bot **de verdad la revise**, hay que guardarla también como `MANYCHAT_WEBHOOK_SECRET` — ese paso viene en el Paso 3.
 
 ---
 
@@ -69,6 +69,17 @@ Aquí le dices a ManyChat: "cuando llegue un mensaje, pregúntale a mi bot qué 
 5. Agrega un **header** (encabezado):
    - Nombre: `X-Api-Key`
    - Valor: tu `MANYCHAT_API_KEY` (la misma llave del Paso 1)
+6. **Ya que guardaste el flujo con el header**, dile a tu bot que empiece a exigirlo:
+   ```bash
+   pnpm wrangler secret put MANYCHAT_WEBHOOK_SECRET
+   ```
+   Pega **el mismo valor** que pusiste en el header y dale Enter. Desde ahí, tu bot
+   contesta `401` a cualquier petición que no traiga esa llave.
+
+   > ⚠️ **En este orden.** Si guardas el secreto ANTES de agregar el header en
+   > ManyChat, tu bot empieza a rechazar los mensajes de tus propios clientes.
+   > Mientras `MANYCHAT_WEBHOOK_SECRET` no exista, el bot acepta todo — igual que
+   > siempre — así que no se te cae nada por dejarlo para el final.
 
 ---
 
@@ -102,7 +113,7 @@ Cuando el bot necesita pasarte un cliente a ti (handoff), **no** te avisa por Ma
 ## Si algo falla
 
 - **El bot no contesta en el canal:** revisa que la URL del External Request termine en `/webhooks/manychat` y que el método sea `POST`.
-- **Error de autorización / rechaza el mensaje:** confirma que agregaste el header `X-Api-Key` con tu `MANYCHAT_API_KEY` exacta, y que corriste `pnpm run deploy` después de guardar el secreto.
+- **Error de autorización / el bot responde `401`:** el valor del header `X-Api-Key` en ManyChat y el de `MANYCHAT_WEBHOOK_SECRET` tienen que ser **idénticos**. Vuelve a guardar el secreto (`pnpm wrangler secret put MANYCHAT_WEBHOOK_SECRET`) copiando y pegando el mismo texto, y corre `pnpm run deploy`.
 - **El cliente no ve la respuesta:** asegúrate de que mapeaste el campo `reply` en la acción "Send Message".
 - **No llega ningún mensaje a tu bot:** revisa que el canal (Instagram/Messenger/etc.) esté bien conectado en ManyChat y que el flujo esté activo (publicado).
 
@@ -114,7 +125,7 @@ Cuando el bot necesita pasarte un cliente a ti (handoff), **no** te avisa por Ma
 |---|---|
 | Secreto | `MANYCHAT_API_KEY` (y `OWNER_TELEGRAM_CHAT_ID` o `TWILIO_HANDOFF_CONTENT_SID` + `OWNER_WA_NUMBER` para los avisos al dueño) |
 | Webhook | `<worker-url>/webhooks/manychat` (método `POST`) |
-| Header | `X-Api-Key: <MANYCHAT_API_KEY>` |
+| Header | `X-Api-Key: <MANYCHAT_API_KEY>` (guarda ese mismo valor como `MANYCHAT_WEBHOOK_SECRET` para que el bot lo exija) |
 | Campo de respuesta | `reply` (mapéalo a "Send Message") |
 | Canales | Instagram, Messenger, WhatsApp, Telegram (conectados en ManyChat) |
 | Costo | Plan de ManyChat (tiene capa gratis limitada) |

--- a/src/env.ts
+++ b/src/env.ts
@@ -39,6 +39,7 @@ export interface Env {
   RESEND_API_KEY?: string;
   TELEGRAM_BOT_TOKEN?: string;
   MANYCHAT_API_KEY?: string;
+  MANYCHAT_WEBHOOK_SECRET?: string;  // shared secret expected in the X-Api-Key header on /webhooks/manychat; unset = guard off
   MANYCHAT_CONTENT_TYPE?: "instagram" | "whatsapp" | "telegram" | "messenger"; // ManyChat channel for sendContent; defaults to "instagram"
   TWILIO_ACCOUNT_SID?: string;
   TWILIO_AUTH_TOKEN?: string;

--- a/src/http-auth.ts
+++ b/src/http-auth.ts
@@ -31,22 +31,34 @@ export const MANYCHAT_SECRET_HEADER = "X-Api-Key";
 /**
  * Fail-OPEN auth for the `/webhooks/manychat` ingress.
  *
- * Passes when MANYCHAT_WEBHOOK_SECRET is unset (nothing changes for bots that
- * are already running) or when the request carries a matching `X-Api-Key`
- * header (constant-time compare via tokensMatch).
+ * Passes when MANYCHAT_WEBHOOK_SECRET was never configured (nothing changes for
+ * bots that are already running) or when the request carries a matching
+ * `X-Api-Key` header (constant-time compare via tokensMatch).
  *
- * Fail-open is deliberate here, unlike requireControlPlane. The setup guide has
- * been telling members to add this header for a while, but the route never read
- * it — so a fail-closed default would 401 every bot whose owner skipped that
- * step, and inbound messages would silently stop. Opening up lets the fix ship
- * in a safe order:
+ * Fail-open on an ABSENT secret is deliberate here, unlike requireControlPlane.
+ * The setup guide has been telling members to add this header for a while, but
+ * the route never read it — so a fail-closed default would 401 every bot whose
+ * owner skipped that step, and inbound messages would silently stop. Opening up
+ * lets the fix ship in a safe order:
  *   1. deploy (no behaviour change)
  *   2. add the header in the ManyChat External Request
  *   3. `wrangler secret put MANYCHAT_WEBHOOK_SECRET` → enforced from here on
+ *
+ * A secret that IS configured but blank is a different case: the owner believes
+ * the webhook is protected. Treating that as "guard off" would leave them open
+ * while thinking otherwise — the exact failure this function exists to remove —
+ * so it fails closed and says why.
  */
 export function manychatWebhookAllowed(req: Request, env: Env): boolean {
-  const expected = env.MANYCHAT_WEBHOOK_SECRET?.trim();
-  if (!expected) return true; // guard off → previous behaviour
+  const configured = env.MANYCHAT_WEBHOOK_SECRET;
+  if (configured === undefined) return true; // never set → previous behaviour
+  const expected = configured.trim();
+  if (!expected) {
+    console.error(
+      "MANYCHAT_WEBHOOK_SECRET is set but blank — rejecting every ManyChat webhook. Set a real value, or unset it to turn the guard off.",
+    );
+    return false;
+  }
   const received = req.headers.get(MANYCHAT_SECRET_HEADER)?.trim() ?? "";
   return tokensMatch(received, expected);
 }

--- a/src/http-auth.ts
+++ b/src/http-auth.ts
@@ -24,3 +24,29 @@ export function requireControlPlane(req: Request, env: Env): boolean {
   if (!match) return false;
   return tokensMatch(match[1].trim(), expected);
 }
+
+/** Header ManyChat sends the shared secret in (see the ManyChat setup guide). */
+export const MANYCHAT_SECRET_HEADER = "X-Api-Key";
+
+/**
+ * Fail-OPEN auth for the `/webhooks/manychat` ingress.
+ *
+ * Passes when MANYCHAT_WEBHOOK_SECRET is unset (nothing changes for bots that
+ * are already running) or when the request carries a matching `X-Api-Key`
+ * header (constant-time compare via tokensMatch).
+ *
+ * Fail-open is deliberate here, unlike requireControlPlane. The setup guide has
+ * been telling members to add this header for a while, but the route never read
+ * it — so a fail-closed default would 401 every bot whose owner skipped that
+ * step, and inbound messages would silently stop. Opening up lets the fix ship
+ * in a safe order:
+ *   1. deploy (no behaviour change)
+ *   2. add the header in the ManyChat External Request
+ *   3. `wrangler secret put MANYCHAT_WEBHOOK_SECRET` → enforced from here on
+ */
+export function manychatWebhookAllowed(req: Request, env: Env): boolean {
+  const expected = env.MANYCHAT_WEBHOOK_SECRET?.trim();
+  if (!expected) return true; // guard off → previous behaviour
+  const received = req.headers.get(MANYCHAT_SECRET_HEADER)?.trim() ?? "";
+  return tokensMatch(received, expected);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { Db } from "./db/client";
 import { SettingsRepo, SETTING_KEYS } from "./db/settings";
 import { detectKind } from "./learn/fieldPath";
 import { saveCapture, isLearnMode } from "./learn/mapping";
-import { tokensMatch } from "./http-auth";
+import { tokensMatch, manychatWebhookAllowed } from "./http-auth";
 import { apiApp } from "./api";
 
 export { SupportAgent } from "./agent";
@@ -55,7 +55,15 @@ async function routeToAgent(c: { req: { raw: Request }; env: Env; text: (t: stri
 }
 
 app.post("/webhooks/telegram", (c) => routeToAgent(c, telegramAdapter));
-app.post("/webhooks/manychat", (c) => routeToAgent(c, manychatAdapter));
+// ManyChat — guarded by the X-Api-Key header the setup guide already asks for.
+// No-op until MANYCHAT_WEBHOOK_SECRET is set, so existing bots keep working.
+app.post("/webhooks/manychat", (c) => {
+  if (!manychatWebhookAllowed(c.req.raw, c.env)) {
+    console.warn("manychat webhook rejected: missing or invalid X-Api-Key");
+    return c.text("unauthorized", 401);
+  }
+  return routeToAgent(c, manychatAdapter);
+});
 // WhatsApp (Twilio): rutea el mensaje entrante al bot de clientes (Claude). El
 // body se lee UNA vez; ack con TwiML vacío para que Twilio no reenvíe el cuerpo
 // como mensaje.

--- a/test/http-auth.test.ts
+++ b/test/http-auth.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { manychatWebhookAllowed, MANYCHAT_SECRET_HEADER } from "../src/http-auth";
+import type { Env } from "../src/env";
+
+const envWith = (secret?: string) =>
+  ({ MANYCHAT_WEBHOOK_SECRET: secret }) as unknown as Env;
+
+/** POST to the webhook, optionally carrying the X-Api-Key header. */
+const post = (apiKey?: string) =>
+  new Request("https://bot.example.workers.dev/webhooks/manychat", {
+    method: "POST",
+    headers: apiKey === undefined ? {} : { [MANYCHAT_SECRET_HEADER]: apiKey },
+    body: "{}",
+  });
+
+describe("manychatWebhookAllowed", () => {
+  it("accepts a request whose header matches the secret", () => {
+    expect(manychatWebhookAllowed(post("s3cr3t"), envWith("s3cr3t"))).toBe(true);
+  });
+
+  it("rejects a different secret", () => {
+    expect(manychatWebhookAllowed(post("nope"), envWith("s3cr3t"))).toBe(false);
+  });
+
+  it("rejects a request with no header at all", () => {
+    expect(manychatWebhookAllowed(post(), envWith("s3cr3t"))).toBe(false);
+  });
+
+  it("rejects a correct prefix — guessing the start is not enough", () => {
+    expect(manychatWebhookAllowed(post("s3c"), envWith("s3cr3t"))).toBe(false);
+  });
+
+  it("rejects trailing extra characters", () => {
+    expect(manychatWebhookAllowed(post("s3cr3tX"), envWith("s3cr3t"))).toBe(false);
+  });
+
+  it("reads the header case-insensitively, as HTTP requires", () => {
+    const req = new Request("https://bot.example.workers.dev/webhooks/manychat", {
+      method: "POST",
+      headers: { "x-api-key": "s3cr3t" },
+      body: "{}",
+    });
+    expect(manychatWebhookAllowed(req, envWith("s3cr3t"))).toBe(true);
+  });
+
+  // Fail-open is deliberate: it lets the fix deploy before members have added
+  // the header in ManyChat, instead of 401-ing their live inbound traffic.
+  it("lets everything through while the secret is unset", () => {
+    expect(manychatWebhookAllowed(post(), envWith(undefined))).toBe(true);
+    expect(manychatWebhookAllowed(post("anything"), envWith(""))).toBe(true);
+    expect(manychatWebhookAllowed(post(), envWith("   "))).toBe(true);
+  });
+
+  it("ignores surrounding whitespace, so a pasted newline does not break it", () => {
+    expect(manychatWebhookAllowed(post(" s3cr3t "), envWith("s3cr3t\n"))).toBe(true);
+  });
+
+  it("expects the header the setup guide documents", () => {
+    expect(MANYCHAT_SECRET_HEADER).toBe("X-Api-Key");
+  });
+});

--- a/test/http-auth.test.ts
+++ b/test/http-auth.test.ts
@@ -45,10 +45,16 @@ describe("manychatWebhookAllowed", () => {
 
   // Fail-open is deliberate: it lets the fix deploy before members have added
   // the header in ManyChat, instead of 401-ing their live inbound traffic.
-  it("lets everything through while the secret is unset", () => {
+  it("lets everything through while the secret was never set", () => {
     expect(manychatWebhookAllowed(post(), envWith(undefined))).toBe(true);
-    expect(manychatWebhookAllowed(post("anything"), envWith(""))).toBe(true);
-    expect(manychatWebhookAllowed(post(), envWith("   "))).toBe(true);
+    expect(manychatWebhookAllowed(post("anything"), envWith(undefined))).toBe(true);
+  });
+
+  // But a secret that IS configured and blank means the owner thinks they are
+  // protected. Silently opening up there would recreate the very bug this fixes.
+  it("fails closed on a configured but blank secret", () => {
+    expect(manychatWebhookAllowed(post("anything"), envWith(""))).toBe(false);
+    expect(manychatWebhookAllowed(post(), envWith("   "))).toBe(false);
   });
 
   it("ignores surrounding whitespace, so a pasted newline does not break it", () => {


### PR DESCRIPTION
## El problema

La guía del canal promete, en el Paso 1, que el header `X-Api-Key` protege el webhook:

> Esta misma llave la vas a usar más abajo como un encabezado (`X-Api-Key`) para que tu bot **confirme que el mensaje viene de TU ManyChat y no de un desconocido**.

La sección "Si algo falla" incluso documenta cómo resolver un **"Error de autorización / rechaza el mensaje"**.

Pero la ruta nunca leía ese header:

```ts
app.post("/webhooks/manychat", (c) => routeToAgent(c, manychatAdapter));
```

`MANYCHAT_API_KEY` solo se usa para mandar respuestas **hacia** ManyChat, nunca para validar lo que entra. El miembro configura el header, la guía le dice que está protegido, y no lo está. El error de autorización que documenta la guía **no puede ocurrir**.

## Cómo lo encontramos

Operando un bot de Forja en producción — una clínica estética atendiendo Instagram vía ManyChat.

Contra el worker desplegado, **dos POST sin credencial alguna crearon dos conversaciones** en el panel. Con texto real el bot habría contestado, gastado la llave de IA del miembro y —en bots con agenda conectada— **agendado una cita falsa**.

La URL del worker no es secreta: aparece en la config de ManyChat, en capturas de pantalla y en los mensajes de soporte de la comunidad.

Vale la pena notar que el resto de la plantilla sí se cuida: `/api/*` es fail-closed con Bearer, `/kb/reindex` valida `X-Reindex-Token` con `tokensMatch`, y los webhooks de Meta verifican firma. ManyChat es el caso donde **la documentación promete una validación que el código no hace**.

## El cambio

Reusa `tokensMatch`, que ya vivía en `src/http-auth.ts` — no agrega ningún helper nuevo.

```ts
export function manychatWebhookAllowed(req: Request, env: Env): boolean {
  const expected = env.MANYCHAT_WEBHOOK_SECRET?.trim();
  if (!expected) return true; // guard off → previous behaviour
  const received = req.headers.get(MANYCHAT_SECRET_HEADER)?.trim() ?? "";
  return tokensMatch(received, expected);
}
```

### Fail-open a propósito

Al revés que `requireControlPlane`. Si `MANYCHAT_WEBHOOK_SECRET` no está configurado se acepta todo, **igual que hoy**.

Un default fail-closed dejaría sin mensajes entrantes a todo bot cuyo dueño se saltó el paso del header — y como ese paso nunca hizo nada, es razonable que muchos lo hayan omitido. Así el fix se despliega en orden seguro:

1. deploy → no cambia nada para nadie
2. el miembro agrega el header en la External Request
3. `wrangler secret put MANYCHAT_WEBHOOK_SECRET` → desde ahí se exige

Al revés, el bot dejaría de recibir mensajes entre el paso 3 y el 2. La guía queda actualizada con ese orden y con la advertencia de no invertirlo.

Si más adelante quieres endurecerlo a fail-closed una vez que la guía se haya propagado, el cambio es una línea.

## Pruebas

`test/http-auth.test.ts` — 9 casos: secret correcto, distinto, ausente, prefijo correcto (no basta acertar el principio), sobrante al final, header en minúsculas (HTTP es case-insensitive), guarda apagada en sus tres formas, espacios alrededor, y el nombre del header.

```
pnpm typecheck   ✅
pnpm test        ✅  66 archivos, 446 pruebas
```

## Archivos

| Archivo | Qué cambia |
|---|---|
| `src/http-auth.ts` | `+MANYCHAT_SECRET_HEADER`, `+manychatWebhookAllowed()` |
| `src/index.ts` | import + guarda de 401 en la ruta |
| `src/env.ts` | `MANYCHAT_WEBHOOK_SECRET?: string` |
| `test/http-auth.test.ts` | nuevo, 9 pruebas |
| `skill/…/manychat-webhook.md` | el paso del secret, el orden, y el troubleshooting |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional API-key authentication for ManyChat webhooks.
  - Unauthorized requests now receive a `401` response when the configured key is missing or incorrect.
  - Requests continue normally when the correct key is provided.

- **Documentation**
  - Updated setup and troubleshooting guidance for configuring and validating the ManyChat webhook key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->