### PR TITLE
Fix: cambiar el cron apaga en silencio la purga, los insights, el flywheel y el reporte diario

### DIFF
--- a/src/crons/schedule.ts
+++ b/src/crons/schedule.ts
@@ -1,0 +1,38 @@
+/**
+ * Which scheduled tick is allowed to run the nightly maintenance jobs (purge,
+ * insights, flywheel, owner report).
+ *
+ * The scheduled handler needs to tell the nightly tick apart from any extra,
+ * more frequent trigger a member adds, so the heavy jobs don't run on every
+ * tick. That check used to be a bare string literal against "0 3 * * *".
+ *
+ * The trap: the literal is the ONLY thing that identifies the nightly tick, and
+ * nothing ties it to wrangler.toml. A member who *edits* their cron rather than
+ * adding a second one — say to `0 * * * *`, so follow-ups run hourly — makes the
+ * comparison fail on every tick. Purge, insights, flywheel and the daily owner
+ * report just stop, with no error and nothing in the logs. Even a stray double
+ * space inside the expression is enough.
+ *
+ * So: one exported constant, whitespace-tolerant matching, and a log line when a
+ * tick is skipped. `test/crons/schedule.test.ts` reads wrangler.toml and fails
+ * if the two ever drift apart.
+ */
+
+/** Nightly maintenance window. MUST match [triggers] crons in wrangler.toml. */
+export const DAILY_CRON = "0 3 * * *";
+
+/** Collapse runs of whitespace so "0  3 * * *" still matches "0 3 * * *". */
+function normalize(cron: string): string {
+  return cron.trim().replace(/\s+/g, " ");
+}
+
+/**
+ * True when this tick should run the nightly jobs.
+ *
+ * An undefined cron (a manual/test invocation of the scheduled handler) counts
+ * as the nightly tick — that matches the previous behaviour.
+ */
+export function isNightlyTick(cron: string | undefined): boolean {
+  if (!cron) return true;
+  return normalize(cron) === DAILY_CRON;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { parseMetaEvents, verifyMetaSignature } from "./channels/meta";
 import { parseWhatsAppEvents, serveWhatsAppMedia } from "./channels/whatsapp";
 import { adminApp } from "./admin/routes";
 import { purgeOldMessages } from "./crons/purgeOldMessages";
+import { DAILY_CRON, isNightlyTick } from "./crons/schedule";
 import { reindexKb } from "./kb/reindex";
 import { analyzeConversations } from "./insights/analyzer";
 import { Db } from "./db/client";
@@ -237,7 +238,13 @@ export default {
 
     // Los trabajos nocturnos SOLO corren en el tick diario (3am UTC) — un tick
     // más frecuente (si el miembro lo configura) no debe purgar/analizar de más.
-    if (event.cron && event.cron !== "0 3 * * *") return;
+    // Ojo: si NINGÚN cron configurado es DAILY_CRON, estos trabajos no corren
+    // nunca. Por eso se loguea el motivo, y por eso el test compara la constante
+    // contra wrangler.toml.
+    if (!isNightlyTick(event.cron)) {
+      console.log(`cron ${event.cron}: se omiten los trabajos nocturnos (solo corren en "${DAILY_CRON}")`);
+      return;
+    }
 
     // Daily cron (wrangler.toml: "0 3 * * *") — purge messages older than 90 days.
     await purgeOldMessages(env);

--- a/test/crons/schedule.test.ts
+++ b/test/crons/schedule.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { DAILY_CRON, isNightlyTick } from "../../src/crons/schedule";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+/** The `crons = [...]` entries declared under [triggers] in wrangler.toml. */
+function configuredCrons(): string[] {
+  const toml = readFileSync(path.join(ROOT, "wrangler.toml"), "utf8");
+  const block = /^\s*crons\s*=\s*\[([^\]]*)\]/m.exec(toml);
+  if (!block) throw new Error("no crons array found in wrangler.toml");
+  return [...block[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+}
+
+describe("isNightlyTick", () => {
+  it("runs the nightly jobs on the daily tick", () => {
+    expect(isNightlyTick(DAILY_CRON)).toBe(true);
+  });
+
+  it("skips them on an extra, more frequent tick", () => {
+    expect(isNightlyTick("*/15 * * * *")).toBe(false);
+    expect(isNightlyTick("0 * * * *")).toBe(false);
+  });
+
+  it("tolerates sloppy whitespace instead of silently skipping forever", () => {
+    expect(isNightlyTick("0  3 * * *")).toBe(true);
+    expect(isNightlyTick(" 0 3 * * * ")).toBe(true);
+  });
+
+  it("treats a manual invocation (no cron) as the nightly tick", () => {
+    expect(isNightlyTick(undefined)).toBe(true);
+  });
+});
+
+describe("wrangler.toml", () => {
+  // The guard rail. If someone edits [triggers] crons and drops the nightly
+  // expression, purge / insights / flywheel / owner report stop running with no
+  // error anywhere. Failing here is the only loud signal that exists.
+  it("still schedules the cron the nightly jobs wait for", () => {
+    const crons = configuredCrons();
+    expect(crons.length).toBeGreaterThan(0);
+    expect(crons.some((c) => isNightlyTick(c))).toBe(true);
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -58,6 +58,9 @@ DASHBOARD_BASE_URL = "https://horizontes-bot-{{BOT_SLUG}}.workers.dev"
 #   CONTROL_PLANE_URL          optional (var) — base URL of the control plane (future reports / license check)
 
 [triggers]
+# AGREGA ticks aquí si los necesitas, pero NO quites "0 3 * * *": los trabajos
+# nocturnos (purga, insights, flywheel, reporte al dueño) solo corren en ese tick
+# — ver DAILY_CRON en src/crons/schedule.ts. Sin él dejan de correr en silencio.
 crons = ["0 3 * * *"]  # daily 3am UTC: purge old messages
 
 # DASHBOARD_PASSWORD  (secret) — HTTP Basic Auth password for the admin dashboard; username is always "admin".


### PR DESCRIPTION
## El problema

El handler programado distingue la corrida nocturna de cualquier tick extra comparando contra un literal:

```ts
if (event.cron && event.cron !== "0 3 * * *") return;
```

La intención está clara en el comentario y es correcta: un tick más frecuente no debe purgar ni analizar de más.

El problema es que **ese literal es lo único que identifica al tick nocturno**, y nada lo ata a `wrangler.toml`. Si el miembro **edita** su cron en vez de agregar uno, la comparación falla en *todos* los ticks y se apagan:

- la purga de mensajes a 90 días
- el analista de insights
- el flywheel de mejoras
- el reporte diario al dueño

Sin error, sin log, sin nada en el panel. Un doble espacio dentro de la expresión (`"0  3 * * *"`) produce exactamente el mismo resultado.

## Cómo lo encontramos

Queríamos que `runFollowups` corriera más seguido que una vez al día. El arreglo obvio —cambiar el cron a `0 * * * *`— habría apagado los cuatro trabajos nocturnos sin decir nada. Lo notamos leyendo esa línea; si no la lees, no hay forma de enterarte.

Terminamos **agregando** un cron en vez de reemplazarlo, que es lo correcto, pero no hay nada que empuje al miembro hacia esa decisión.

## El cambio

Sin cambio de comportamiento, salvo un log.

**`src/crons/schedule.ts`** (nuevo):

```ts
export const DAILY_CRON = "0 3 * * *";

export function isNightlyTick(cron: string | undefined): boolean {
  if (!cron) return true;
  return cron.trim().replace(/\s+/g, " ") === DAILY_CRON;
}
```

**`src/index.ts`** — la razón del salto deja de ser invisible:

```ts
if (!isNightlyTick(event.cron)) {
  console.log(`cron ${event.cron}: se omiten los trabajos nocturnos (solo corren en "${DAILY_CRON}")`);
  return;
}
```

**`wrangler.toml`** — el aviso donde el miembro va a estar editando:

```toml
# AGREGA ticks aquí si los necesitas, pero NO quites "0 3 * * *": los trabajos
# nocturnos (purga, insights, flywheel, reporte al dueño) solo corren en ese tick
# — ver DAILY_CRON en src/crons/schedule.ts. Sin él dejan de correr en silencio.
crons = ["0 3 * * *"]
```

## La prueba que importa

`test/crons/schedule.test.ts` lee `wrangler.toml` y falla si la constante y la configuración se separan:

```ts
it("still schedules the cron the nightly jobs wait for", () => {
  const crons = configuredCrons();
  expect(crons.some((c) => isNightlyTick(c))).toBe(true);
});
```

Verificado que muerde: al cambiar el cron a `0 * * * *` la prueba falla. Es la única señal ruidosa que existe para esta falla.

Los otros 4 casos cubren el tick diario, un tick más frecuente, espacios sobrantes y la invocación manual sin cron.

```
pnpm typecheck   ✅
pnpm test        ✅  66 archivos, 442 pruebas
```

## Nota aparte

Mientras revisábamos esto vimos que `src/followup/run.ts` no comprueba la hora del día: persigue leads con 3–20 h de inactividad y depende por completo del cron para no escribir de madrugada. Con un cron horario, un lead nuestro recibió un mensaje **a las 00:00**. Si te interesa, lo abro como issue aparte — no lo metí aquí porque es otro tema.
