### PR TITLE
El bot manda mensajes EN BLANCO cuando el proveedor falla a mitad del stream

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -41,6 +41,11 @@ export interface AgentIncomingPayload {
   isOwnerMessage?: boolean;
 }
 
+// Lo que recibe el cliente cuando el LLM no logró producir texto — ni con
+// reintentos ni con el proveedor alterno. Vive aquí, y no en línea, porque hay
+// dos caminos que terminan aquí: el failover agotado y el guard de texto vacío.
+const FALLBACK_REPLY = "Algo falló de mi lado, intenta de nuevo en un momento.";
+
 export class SupportAgent extends Agent<Env, SupportAgentState> {
   initialState: SupportAgentState = {
     conversationId: null,
@@ -339,6 +344,18 @@ export class SupportAgent extends Agent<Env, SupportAgentState> {
       for await (const chunk of result.textStream) {
         text += chunk;
       }
+      // Un error del proveedor A MITAD del stream (p. ej. `server_error` de
+      // OpenAI) NO llega como excepción: `textStream` simplemente termina y
+      // `text` queda vacío. Sin este guard el turno se daba por bueno, el
+      // FAILOVER de abajo nunca entraba, y el cliente recibía un mensaje EN
+      // BLANCO — peor que un error, porque parece que el bot lo ignoró.
+      // Tratarlo como fallo activa el failover que ya existe: reintento con
+      // backoff, proveedor alterno y, si nada sirve, FALLBACK_REPLY.
+      if (!text.trim()) {
+        throw new Error(
+          "[SupportAgent] el modelo terminó el stream sin texto (posible error del proveedor)",
+        );
+      }
       assistantText = text;
       const usage = await result.usage;
       inputTokens = usage?.inputTokens ?? 0;
@@ -401,8 +418,21 @@ export class SupportAgent extends Agent<Env, SupportAgentState> {
       }
 
       if (!ok) {
-        assistantText = "Algo falló de mi lado, intenta de nuevo en un momento.";
+        assistantText = FALLBACK_REPLY;
       }
+    }
+
+    // Red de seguridad final: pase lo que pase arriba (un camino nuevo, un
+    // guard que cambie), NUNCA se persiste ni se envía un mensaje vacío. Va
+    // ANTES del append para que el historial y lo que recibe el cliente
+    // coincidan: si se pone después, el cliente ve el fallback pero en la
+    // conversación queda el mensaje en blanco y el panel sigue mostrando el
+    // síntoma original — que fue justo lo que hizo difícil diagnosticarlo.
+    if (!assistantText.trim()) {
+      console.error(
+        "[SupportAgent.processBuffer] texto vacío antes de enviar — se usa el fallback",
+      );
+      assistantText = FALLBACK_REPLY;
     }
 
     // Persist assistant message (with usage + model_used + tool calls)

--- a/test/agent.empty-stream.test.ts
+++ b/test/agent.empty-stream.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mismo patrón que test/agent.media.test.ts: `SupportAgent` extiende `Agent` del
+// SDK `agents`, que importa el módulo virtual `cloudflare:workers` al cargarse y
+// Node no sabe resolver fuera de workerd. Se mockea para que el grafo de imports
+// se quede en Node-land.
+vi.mock("agents", () => ({
+  Agent: class {
+    ctx: any;
+    env: any;
+    state: any;
+    constructor(ctx: any, env: any) {
+      this.ctx = ctx;
+      this.env = env;
+    }
+    setState(s: any) {
+      this.state = s;
+    }
+    sql(..._args: any[]) {
+      return undefined;
+    }
+  },
+}));
+
+import { SupportAgent } from "../src/agent";
+import { ConversationsRepo } from "../src/db/conversations";
+import { MessagesRepo } from "../src/db/messages";
+import { SettingsRepo } from "../src/db/settings";
+import * as senderMod from "../src/replies/sender";
+
+const FALLBACK = "Algo falló de mi lado, intenta de nuevo en un momento.";
+
+const streamTextMock = vi.fn();
+
+vi.mock("ai", () => ({
+  streamText: (...args: any[]) => streamTextMock(...args),
+  tool: (def: any) => def,
+}));
+
+vi.mock("@ai-sdk/anthropic", () => ({
+  createAnthropic: () => (modelId: string) => ({ modelId }),
+}));
+
+/** Resultado de streamText que emite `text` (cadena vacía = error a mitad del stream). */
+function makeStreamResult(text: string) {
+  async function* gen() {
+    if (text) yield text;
+  }
+  return {
+    textStream: gen(),
+    usage: Promise.resolve({
+      inputTokens: 100,
+      outputTokens: 50,
+      cachedInputTokens: 0,
+    }),
+    steps: Promise.resolve([{ toolCalls: [] }]),
+  };
+}
+
+function makeAgent() {
+  const storage = { setAlarm: vi.fn(), getAlarm: vi.fn() };
+
+  const env: any = {
+    DB: {},
+    AI: { run: vi.fn(async () => ({ text: "" })) },
+    ANTHROPIC_API_KEY: "sk-test",
+    BOT_TIER: "free",
+    BOT_LANGUAGE: "es",
+    BUFFER_SECONDS: "8",
+    BOT_NAME: "TestBot",
+    BUSINESS_NAME: "TestCo",
+  };
+
+  const agent: any = new (SupportAgent as any)({ storage }, env);
+  agent.setState({
+    conversationId: "conv-1",
+    channel: "telegram",
+    channelUserId: "u1",
+    pendingMessages: [],
+    lastAlarmAt: 0,
+    lastUserLang: "es",
+    toolCallsInLast2Turns: 0,
+    lastSearchKbScore: 1,
+    imageRetryCount: 0,
+  });
+
+  return { agent, env, storage };
+}
+
+/**
+ * Regresión: un error del proveedor a MITAD del stream no llega como excepción —
+ * `textStream` simplemente termina vacío. Antes del fix, el turno se daba por
+ * bueno y el cliente recibía un mensaje EN BLANCO.
+ */
+describe("SupportAgent.processBuffer — stream sin texto", () => {
+  let appendSpy: any;
+  let sendReply: any;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(SettingsRepo.prototype, "all").mockResolvedValue({});
+
+    appendSpy = vi
+      .spyOn(MessagesRepo.prototype, "append")
+      .mockResolvedValue(undefined as any);
+    vi.spyOn(MessagesRepo.prototype, "lastN").mockResolvedValue([
+      { role: "user", content: "¿cuánto cuesta el servicio?" },
+    ] as any);
+    vi.spyOn(ConversationsRepo.prototype, "getOrCreate").mockResolvedValue({
+      id: "conv-1",
+      paused_until: null,
+    } as any);
+    vi.spyOn(ConversationsRepo.prototype, "isPaused").mockResolvedValue(false);
+    vi.spyOn(ConversationsRepo.prototype, "touchLastMessage").mockResolvedValue(
+      undefined as any,
+    );
+
+    sendReply = vi.fn(async () => {});
+    vi.spyOn(senderMod, "pickAdapter").mockReturnValue({ sendReply } as any);
+
+    streamTextMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function correrTurno() {
+    const { agent } = makeAgent();
+    agent.state.pendingMessages = [
+      { text: "¿cuánto cuesta el servicio?", receivedAt: Date.now() },
+    ];
+    await agent.processBuffer();
+    return agent;
+  }
+
+  it("no persiste un mensaje vacío cuando el stream termina sin texto", async () => {
+    // Todos los intentos (primario, reintento y alterno) devuelven vacío.
+    streamTextMock.mockImplementation(() => makeStreamResult(""));
+
+    await correrTurno();
+
+    expect(appendSpy).toHaveBeenCalled();
+    const guardados = appendSpy.mock.calls
+      .filter((c: any[]) => c[1] === "assistant")
+      .map((c: any[]) => c[2] as string);
+
+    expect(guardados.length).toBeGreaterThan(0);
+    for (const texto of guardados) {
+      expect(texto.trim()).not.toBe("");
+    }
+    expect(guardados[guardados.length - 1]).toBe(FALLBACK);
+  });
+
+  it("no envía un mensaje vacío al cliente", async () => {
+    streamTextMock.mockImplementation(() => makeStreamResult(""));
+
+    await correrTurno();
+
+    expect(sendReply).toHaveBeenCalled();
+    for (const call of sendReply.mock.calls) {
+      const enviado = JSON.stringify(call);
+      expect(enviado).not.toMatch(/"\s*"/);
+    }
+  });
+
+  it("el guard activa el failover: se reintenta en vez de darse por bueno", async () => {
+    streamTextMock.mockImplementation(() => makeStreamResult(""));
+
+    await correrTurno();
+
+    // Sin el guard, streamText se llamaba UNA vez y el turno terminaba feliz.
+    expect(streamTextMock.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("un turno normal con texto no se ve afectado", async () => {
+    streamTextMock.mockImplementation(() => makeStreamResult("claro, con gusto"));
+
+    await correrTurno();
+
+    const guardados = appendSpy.mock.calls
+      .filter((c: any[]) => c[1] === "assistant")
+      .map((c: any[]) => c[2] as string);
+
+    expect(guardados).toContain("claro, con gusto");
+    expect(streamTextMock.mock.calls.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## El problema

Si el proveedor emite un error **a mitad del stream** (p. ej. `server_error` de OpenAI), el SDK **no lanza excepción**: `textStream` simplemente termina.

En `src/agent.ts`, dentro de `attempt()`:

```js
let text = "";
for await (const chunk of result.textStream) { text += chunk }
assistantText = text;   // ← queda ""
```

`text` queda vacío, `attempt()` retorna como si todo hubiera ido bien, **el failover nunca se activa** y el turno continúa: se persiste un mensaje vacío y se envía al canal.

Para el cliente es **peor que un error**: parece que el bot lo ignoró. Y para el dueño es casi imposible de diagnosticar, porque en el panel la conversación se ve normal salvo por un mensaje en blanco.

## Cómo lo encontré

En un bot en producción, las preguntas de precio a `gpt-4o-mini` devolvían `server_error` de forma reproducible — **3 de 3 con el mismo prompt**. El log daba el turno por exitoso:

```
(error) { type: 'error', code: 'server_error',
          message: 'An error occurred while processing your request...' }
(log) [SupportAgent.processBuffer] sent 1 chunks, model=gpt-4o-mini, cost=$0.00000
```

Nótese `sent 1 chunks` y `cost=$0.00000`: el turno se cerró sin que nada fallara. (Con `gpt-4.1-mini` los `server_error` desaparecieron, pero eso trata el síntoma, no la causa.)

Afecta a **cualquier bot con cualquier proveedor** — no es específico de OpenAI ni de un giro.

## Qué cambia

Dos cambios en `src/agent.ts`:

1. **Guard dentro de `attempt()`** — si el stream termina sin texto, se lanza. Con eso entra el failover que **ya existe**: reintento con backoff → proveedor alterno → respuesta de fallo. No se agrega maquinaria nueva, solo se deja que la que ya está haga su trabajo.

2. **Red de seguridad antes del `append`** — nunca se persiste ni se envía texto vacío, pase lo que pase arriba.

El orden del segundo importa: lo probé primero *después* del `append` y fue peor de diagnosticar — el cliente recibía el fallback, pero en la conversación quedaba guardado el mensaje vacío y el panel seguía mostrando el síntoma original. Tiene que ir **antes** de persistir para que el historial y lo que recibe el cliente coincidan.

De paso, el texto de fallo se extrae a `FALLBACK_REPLY` porque ahora lo usan dos caminos.

## Tests

Nuevo `test/agent.empty-stream.test.ts` con 4 casos de regresión:

- no persiste un mensaje vacío cuando el stream termina sin texto
- no envía un mensaje vacío al cliente
- el guard activa el failover (antes `streamText` se llamaba una vez y el turno terminaba feliz)
- un turno normal con texto no se ve afectado

Usa el mismo patrón de mocks que `test/agent.media.test.ts`, sin red.

**Suite completa: 441 tests en verde (66 archivos). `tsc --noEmit` limpio.**

## Una consideración

Si algún flujo legítimo termina sin texto —por ejemplo un turno que agota los 6 pasos de `stopWhen` solo con herramientas y no cierra con respuesta—, este guard lo convertiría en un fallo y provocaría un reintento (con su costo).

No encontré ese caso en la implementación que usé ni en los tests del repo, y aun si ocurriera, el resultado sería `FALLBACK_REPLY` en vez de un mensaje en blanco, que sigue siendo mejor para el cliente. Pero conviene contrastarlo contra los otros giros antes de mergear.
