### PR TITLE
forjabot update destruye el trabajo local sin avisar — respaldo y aviso antes de sobrescribir

### DIFF
--- a/cli/bin/cli.js
+++ b/cli/bin/cli.js
@@ -98,6 +98,12 @@ const DICT = {
     updInstalled: (a, b) => `Instalado: v${a}  ·  Última: v${b}`,
     updUpToDate: "Ya estás en la última versión.",
     updDone: (v) => `Actualizado a v${v}  (tu config y tu KB se conservaron)`,
+    updBackupSaved: (f) => `Respaldo previo guardado: ${f}`,
+    updDirtyTitle: "⚠ Esta carpeta tiene cambios propios que el update va a sobrescribir:",
+    updDirtyMore: (n) => `… y ${n} más`,
+    updDirtyRestore: (f) => `Si extrañas algo después, restáuralo desde el respaldo:  tar -xzf ${f}`,
+    updDirtyAsk: "¿Continuar con el update? (s/N) ",
+    updAborted: "Update cancelado — tu carpeta quedó intacta. Haz commit de tus cambios y reintenta.",
     updTierUp: "⚡ Tu licencia es Forja+ — subí tu bot a PRO. Al desplegar, superpoderes prendidos.",
     updPublish: "Para publicar los cambios, pídele a tu agente:",
     updPublishCmd: '"reinstala dependencias y despliega mi bot"',
@@ -205,6 +211,12 @@ const DICT = {
     updInstalled: (a, b) => `Installed: v${a}  ·  Latest: v${b}`,
     updUpToDate: "You're on the latest version.",
     updDone: (v) => `Updated to v${v}  (your config and KB were preserved)`,
+    updBackupSaved: (f) => `Pre-update backup saved: ${f}`,
+    updDirtyTitle: "⚠ This folder has local changes the update is about to overwrite:",
+    updDirtyMore: (n) => `… and ${n} more`,
+    updDirtyRestore: (f) => `If you miss anything afterwards, restore it from the backup:  tar -xzf ${f}`,
+    updDirtyAsk: "Continue with the update? (y/N) ",
+    updAborted: "Update canceled — your folder is untouched. Commit your changes and retry.",
     updTierUp: "⚡ Your license is Forja+ — bumped your bot to PRO. Deploy and the superpowers are on.",
     updPublish: "To publish the changes, ask your agent:",
     updPublishCmd: '"reinstall dependencies and deploy my bot"',
@@ -603,6 +615,47 @@ function extractOver(buf, dir, slug, version) {
     "--exclude=./.bot-state.json", "--exclude=./.bot-setup.json", `--exclude=./${MARKER}`]);
   rmSync(tgz, { force: true });
   writeMarker(dir, slug, version);
+}
+
+// ¿La carpeta del bot tiene cambios sin commit? extractOver preserva member/ y
+// wrangler.toml, pero pisa TODO lo demás (src/, test/, docs/…) sin preguntar.
+// Si el miembro —o su agente— parchó el código local, el update se lo lleva sin
+// remedio (pasó: 282 líneas de parches perdidas; se recuperaron solo porque
+// había un commit de media hora antes). Devuelve: null si no es repo git o no
+// hay git instalado (no podemos saber), [] si está limpio, o las líneas de
+// `git status --porcelain` si hay trabajo en riesgo.
+function gitDirty(dir) {
+  try {
+    if (!existsSync(join(dir, ".git"))) return null;
+    const out = execFileSync("git", ["-C", dir, "status", "--porcelain"], {
+      stdio: ["ignore", "pipe", "ignore"],
+    }).toString().trim();
+    return out ? out.split("\n") : [];
+  } catch {
+    return null; // sin git en el PATH → mismo trato que "no es repo"
+  }
+}
+
+// Respaldo del estado ANTES de sobrescribir: un tarball de la carpeta completa
+// (menos lo pesado/regenerable) en .forja-backup/. Cuesta ~1 s y unos cientos
+// de KB, y convierte "perdí mi trabajo" en un tar -xzf. Usa el mismo tar del
+// que ya depende todo el flujo de install/update. Un archivo por versión de
+// origen: updates repetidos desde la misma versión lo reusan, no se acumulan.
+// Devuelve la ruta relativa del respaldo, o null si no se pudo (el update
+// sigue: el respaldo es protección extra, nunca la ruta crítica).
+function makePreUpdateBackup(dir, fromVersion) {
+  try {
+    const bdir = join(dir, ".forja-backup");
+    mkdirSync(bdir, { recursive: true });
+    const name = `pre-update-v${String(fromVersion).replace(/[^\w.-]+/g, "_")}.tgz`;
+    execFileSync("tar", ["-czf", join(bdir, name), "-C", dir,
+      "--exclude=./node_modules", "--exclude=./.git", "--exclude=./.wrangler",
+      "--exclude=./.forja-backup", // sin esto, cada respaldo se tragaría a los anteriores
+      "."]);
+    return `.forja-backup/${name}`;
+  } catch {
+    return null;
+  }
 }
 
 // Entrega los archivos DEFAULT nuevos de member/ que el miembro aún NO tenga
@@ -1188,6 +1241,37 @@ async function cmdUpdate(dirArg, flags) {
   process.stdout.write(C.dim(`\n  ${t().downloading("v" + bot.version)}`));
   const { buf, version } = await download(bot.slug, key);
   console.log(C.green("✓") + C.dim(` ${(buf.length / 1024).toFixed(0)} KB`));
+
+  // Protección del trabajo local. extractOver pisa src/ y compañía sin avisar;
+  // si hay cambios propios (parches del miembro o de su agente), aquí es donde
+  // se decidía perderlos. Ahora: repo git LIMPIO → nada que hacer, git ya lo
+  // tiene todo. Cualquier otro caso (repo sucio, o carpeta sin git donde no
+  // podemos saber) → respaldo primero. Y si además VEMOS trabajo en riesgo, se
+  // lista y —con humano en la terminal— se pregunta antes de seguir.
+  const dirty = gitDirty(dir);
+  let backupFile = null;
+  if (dirty === null || dirty.length > 0) {
+    backupFile = makePreUpdateBackup(dir, marker.version);
+    if (backupFile) console.log(C.dim("  " + t().updBackupSaved(backupFile)));
+  }
+  if (Array.isArray(dirty) && dirty.length > 0) {
+    console.log("  " + C.yellow(t().updDirtyTitle));
+    dirty.slice(0, 10).forEach((l) => console.log(C.dim("    " + l)));
+    if (dirty.length > 10) console.log(C.dim("    " + t().updDirtyMore(dirty.length - 10)));
+    if (backupFile) console.log(C.dim("  " + t().updDirtyRestore(backupFile)));
+    if (interactive()) {
+      const rl = createInterface({ input, output });
+      const ans = (await rl.question("  " + t().updDirtyAsk)).trim().toLowerCase();
+      rl.close();
+      if (!["s", "si", "sí", "y", "yes"].includes(ans)) {
+        console.log("  " + C.yellow(t().updAborted) + "\n");
+        process.exit(0);
+      }
+    }
+    // No-interactivo (agente/CI con --yes): sigue de largo — el respaldo ya
+    // está hecho y el aviso queda en el log del agente.
+  }
+
   extractOver(buf, dir, bot.slug, version);
   ensureMemberDefaults(buf, dir); // entrega defaults nuevos de member/ sin pisar los del miembro
   console.log(C.green(`\n  ✓ ${t().updDone(version)}\n`));


### PR DESCRIPTION
## El problema

`forjabot update` baja el artifact y lo extrae encima de la instalación. `extractOver()` preserva `member/` y `wrangler.toml`, pero **pisa todo lo demás** — `src/`, `test/`, `docs/` — sin aviso, sin respaldo y sin mirar si hay cambios locales.

Si el miembro (o su agente de Claude Code) parchó el código —un fix propio, un ajuste que el template aún no trae— el update se lo lleva sin remedio. **Caso real: 282 líneas de parches perdidas en un update; se recuperaron solo porque había un commit de media hora antes.** Y el mensaje final — *"tu config y tu KB se conservaron"* — refuerza la sensación de que no se perdió nada.

Con Claude Code como operador habitual de Forja esto pega doble: el agente corre `forjabot update` sin dudarlo, y el dueño se entera del daño hasta que el bot se comporta raro.

## Qué cambia

Tres capas en `cmdUpdate`, entre la descarga y `extractOver()`:

**1. Detección** — `gitDirty(dir)`: si la carpeta es repo git, consulta `git status --porcelain`.
- Repo **limpio** → no hay nada que proteger (git ya lo tiene todo), el update sigue **idéntico a hoy**. Cero fricción para el caso común.
- Sin repo, o sin git en el PATH → no podemos saber → aplica el respaldo.

**2. Respaldo** — `makePreUpdateBackup()`: tarball de la carpeta completa (menos `node_modules`, `.git`, `.wrangler` y el propio `.forja-backup`) en `.forja-backup/pre-update-v<versión>.tgz`, **antes** de tocar nada. Usa el mismo `tar` del que ya depende todo el flujo. Un archivo por versión de origen: updates repetidos lo reusan, no se acumulan. Restaurar = `tar -xzf`.

**3. Aviso** — si hay cambios sin commit, se listan (máx 10) y, con un humano en la terminal, se pregunta `¿Continuar con el update? (s/N)`. En modo no-interactivo (agente/CI con `--yes`) **sigue de largo**: el respaldo ya está hecho y el aviso queda en el log del agente — no se cuelga ningún pipeline.

Mensajes nuevos en los dos idiomas del CLI (es/en). El respaldo nunca es ruta crítica: si `tar` o `git` fallan, el update continúa como hoy.

## Cómo se probó

En Windows (con el `tar` BSD que trae el sistema, el caso más quisquilloso):

- `node --check` limpio.
- Exclusiones del tarball correctas: `node_modules`, `.git` y `.forja-backup` quedan fuera — sin esta última, cada respaldo se tragaría a los anteriores.
- `git status --porcelain` detectando el archivo modificado.
- **El ciclo completo**: parche local → update lo pisa → `tar -xzf` del respaldo → parche de vuelta, byte por byte.

En macOS/Linux los flags usados (`-czf`, `-C`, `--exclude`) son los mismos que `extractOver()` ya usa hoy en producción.

## Consideraciones

- No toco la versión del CLI (`cli/package.json`) — entiendo que el bump lo haces tú al publicar.
- `.forja-backup/` queda dentro de la carpeta del bot. Si prefieres otra ubicación (p. ej. `~/.forja/backups/<slug>/`) es un cambio de una línea.
- Alternativa considerada y descartada: `git stash` automático. Es más invasivo (toca el repo del miembro) y falla justo donde más se necesita — carpetas que no son repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic backups before updates when local changes are detected.
  - Added Git status checks and displays changed files before proceeding.
  - Added confirmation prompts when updates may overwrite local changes.
  - Added Spanish and English messages for backup, warning, restore, confirmation, and cancellation steps.

- **Bug Fixes**
  - Prevented updates from overwriting local changes when confirmation is declined.
  - Non-interactive updates now continue safely after creating a backup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->