### PR TITLE
Instrucciones que se SUMAN al prompt — el camino seguro que faltaba junto al campo que lo borra todo

### DIFF
--- a/src/admin/routes.ts
+++ b/src/admin/routes.ts
@@ -335,6 +335,10 @@ adminApp.post("/agente/node/:id/save", async (c) => {
       await repo.set(SETTING_KEYS.systemPromptOverride, "");
     } else if (form.get("bot_paused") !== null) {
       await repo.set(SETTING_KEYS.botPaused, String(form.get("bot_paused")) === "1" ? "1" : "0");
+    } else if (form.get("custom_instructions") !== null) {
+      // El campo ADITIVO: se suma al prompt generado sin congelarlo. Guardar
+      // vacío = quitar las instrucciones (por eso no se filtra el "").
+      await repo.set(SETTING_KEYS.customInstructions, String(form.get("custom_instructions")).trim());
     } else if (form.get("system_prompt_override") !== null) {
       await repo.set(SETTING_KEYS.systemPromptOverride, String(form.get("system_prompt_override")).trim());
     }

--- a/src/admin/views/agente.ts
+++ b/src/admin/views/agente.ts
@@ -557,6 +557,21 @@ export async function renderNodeModal(env: Env, nodeId: string, saved = false): 
         </button>
       </form>
 
+      <form hx-post="/admin/agente/node/brain/save" hx-target="#modal-root" hx-swap="innerHTML" class="mb-5">
+        <div class="flex items-center justify-between mb-1.5">
+          <label for="custom_instructions" class="text-[12.5px] font-medium text-cream">✍️ Instrucciones</label>
+          <span class="text-[9.5px] tracking-[.05em]" style="color:var(--ok);border:1px solid var(--ok);padding:1px 7px">se suman</span>
+        </div>
+        <p class="text-[11px] mb-2 leading-relaxed" style="color:var(--dim)">Reglas para tu bot — "siempre ofrece agendar una cita al final", "no des precios por chat". Esto se <b>suma</b> al prompt automático: tu información del negocio, el playbook y la base de conocimiento quedan intactos.${hasOverride
+          ? ` <span style="color:var(--accent-2)">⚠ Tienes un prompt manual activo: estas instrucciones no aplican hasta que vuelvas al automático (abajo).</span>`
+          : ""}</p>
+        <textarea id="custom_instructions" name="custom_instructions" rows="4"
+                  placeholder="Ej. Siempre ofrece agendar una cita al final."
+                  class="w-full font-mono text-[11px] p-3 outline-none resize-y"
+                  style="background:var(--bg);border:1px solid var(--line);color:var(--cream)">${esc(d.settings[SETTING_KEYS.customInstructions] ?? "")}</textarea>
+        <button type="submit" class="ghostbtn text-[12.5px] cursor-pointer mt-2" style="background:var(--panel2);border:1px solid var(--line);color:var(--muted);padding:8px 16px">Guardar instrucciones</button>
+      </form>
+
       <form hx-post="/admin/agente/node/brain/save" hx-target="#modal-root" hx-swap="innerHTML">
         <div class="flex items-center justify-between mb-1.5">
           <label for="system_prompt_override" class="text-[12.5px] font-medium text-cream">Prompt del agente</label>

--- a/src/db/settings.ts
+++ b/src/db/settings.ts
@@ -4,6 +4,10 @@ import { Db } from "./client";
 // Empty/absent => default (see settings-loader.ts).
 export const SETTING_KEYS = {
   systemPromptOverride: "system_prompt_override",
+  // Reglas del dueño que se SUMAN al prompt generado; NO lo reemplazan (eso es
+  // system_prompt_override). Es el campo seguro para "siempre ofrece agendar
+  // cita" sin perder el contexto del negocio, el playbook ni el KB.
+  customInstructions: "custom_instructions",
   businessContext: "business_context",
   botName: "bot_name",
   tone: "tone",

--- a/src/settings-loader.ts
+++ b/src/settings-loader.ts
@@ -91,6 +91,10 @@ export async function resolveAgentConfig(env: Env, toolNames: string[]): Promise
   const niche = getNiche(env);
 
   const systemPromptOverride = get(SETTING_KEYS.systemPromptOverride);
+  // Reglas del dueño que se SUMAN al prompt GENERADO (mismo trato que las
+  // lecciones): con un override manual activo no aplican — el override es
+  // "úsalo tal cual", y el panel lo advierte junto al campo.
+  const customInstructions = get(SETTING_KEYS.customInstructions);
   const businessContext = get(SETTING_KEYS.businessContext) ?? renderBusinessContext();
   const botName = get(SETTING_KEYS.botName) ?? env.BOT_NAME;
   // Tono elegido en el panel gana; si no hay, el tono por defecto del nicho.
@@ -117,6 +121,7 @@ export async function resolveAgentConfig(env: Env, toolNames: string[]): Promise
       extraEscalationKeywords: escalationKeywords,
       botName,
       lessons,
+      customInstructions,
     });
 
   const bufferSecondsRaw = get(SETTING_KEYS.bufferSeconds);

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -10,6 +10,7 @@ export interface SystemPromptInput {
   tone?: string;                    // owner-chosen tone (e.g. "cálido y cercano")
   extraEscalationKeywords?: string[]; // extra words that trigger a human handoff
   lessons?: string[];               // flywheel: rules distilled from owner takeovers
+  customInstructions?: string;      // owner rules ADDED to the generated prompt (never replace it)
 }
 
 const TEMPLATE = `<output_language>
@@ -68,6 +69,8 @@ Si una pregunta no tiene respuesta en lo que sabes, escalas a un humano.
 
 {{LECCIONES}}
 
+{{INSTRUCCIONES}}
+
 <escalation_rules>
 Llama handoffHuman cuando:
 - El cliente lo pide explícitamente ("humano", "real person", "alguien", "el dueño").
@@ -122,6 +125,16 @@ ${lessons.map((l) => `- ${l}`).join("\n")}
 </lecciones_aprendidas>`
       : "";
 
+  // Reglas escritas por el dueño en el panel. Se SUMAN al prompt generado —
+  // el resto del cerebro (contexto, playbook, KB, anti-invento) queda intacto.
+  const instructions = input.customInstructions?.trim();
+  const instructionsBlock = instructions
+    ? `<instrucciones_del_negocio>
+Reglas adicionales del dueño del negocio. Síguelas SIEMPRE:
+${instructions}
+</instrucciones_del_negocio>`
+    : "";
+
   return TEMPLATE
     .replaceAll("{{LANGUAGE}}", input.language)
     .replaceAll("{{BOT_NAME}}", input.botName)
@@ -130,6 +143,7 @@ ${lessons.map((l) => `- ${l}`).join("\n")}
     .replaceAll("{{TOOL_LIST}}", toolList)
     .replaceAll("{{NICHO_PLAYBOOK}}", input.nichoPlaybook ?? "")
     .replaceAll("{{LECCIONES}}", lessonsBlock)
+    .replaceAll("{{INSTRUCCIONES}}", instructionsBlock)
     .replaceAll("{{TONE_LINE}}", toneLine)
     .replaceAll("{{EXTRA_ESCALATION}}", extraEscalation);
 }
@@ -139,6 +153,7 @@ export interface SystemPromptOverrides {
   extraEscalationKeywords?: string[];
   botName?: string;
   lessons?: string[];
+  customInstructions?: string;
 }
 
 export function systemPromptFromEnv(
@@ -158,5 +173,6 @@ export function systemPromptFromEnv(
     tone: overrides?.tone,
     extraEscalationKeywords: overrides?.extraEscalationKeywords,
     lessons: overrides?.lessons,
+    customInstructions: overrides?.customInstructions,
   });
 }

--- a/test/settings-loader.test.ts
+++ b/test/settings-loader.test.ts
@@ -146,6 +146,35 @@ describe("resolveAgentConfig — temperature", () => {
   });
 });
 
+describe("resolveAgentConfig — custom_instructions", () => {
+  it("suma las instrucciones al prompt generado sin congelarlo", async () => {
+    await repo.set(SETTING_KEYS.customInstructions, "Siempre ofrece agendar una cita al final.");
+    const cfg = await resolveAgentConfig(env, TOOLS);
+    expect(cfg.systemPrompt).toContain("<instrucciones_del_negocio>");
+    expect(cfg.systemPrompt).toContain("Siempre ofrece agendar una cita al final.");
+    // El resto del cerebro sigue ahí — sumar, no reemplazar:
+    expect(cfg.systemPrompt).toContain("<role>");
+    expect(cfg.systemPrompt).toContain("<business_context>");
+    expect(cfg.systemPrompt).toContain("<anti_patterns>");
+  });
+
+  it("omite el bloque cuando no hay instrucciones (o son espacios)", async () => {
+    let cfg = await resolveAgentConfig(env, TOOLS);
+    expect(cfg.systemPrompt).not.toContain("<instrucciones_del_negocio>");
+
+    await repo.set(SETTING_KEYS.customInstructions, "   ");
+    cfg = await resolveAgentConfig(env, TOOLS);
+    expect(cfg.systemPrompt).not.toContain("<instrucciones_del_negocio>");
+  });
+
+  it("con un prompt manual activo NO aplican (el override es 'tal cual')", async () => {
+    await repo.set(SETTING_KEYS.customInstructions, "Siempre ofrece agendar una cita.");
+    await repo.set(SETTING_KEYS.systemPromptOverride, "MI PROMPT CUSTOM");
+    const cfg = await resolveAgentConfig(env, TOOLS);
+    expect(cfg.systemPrompt).toBe("MI PROMPT CUSTOM");
+  });
+});
+
 describe("resolveAgentConfig — learned lessons (flywheel)", () => {
   it("injects lessons into the generated prompt", async () => {
     await repo.set(SETTING_KEYS.learnedLessons, JSON.stringify(["Confirma el pago antes de prometer acceso."]));

--- a/test/system-prompt.test.ts
+++ b/test/system-prompt.test.ts
@@ -52,6 +52,23 @@ describe("renderSystemPrompt", () => {
     expect(prompt).toContain("Horarios: Lun-Sáb 10am-8pm");
   });
 
+  it("renders customInstructions as an additive block and omits it when absent", () => {
+    const withInstructions = renderSystemPrompt({
+      ...input,
+      customInstructions: "Siempre ofrece agendar una cita al final.",
+    });
+    expect(withInstructions).toContain("<instrucciones_del_negocio>");
+    expect(withInstructions).toContain("Siempre ofrece agendar una cita al final.");
+
+    const without = renderSystemPrompt(input);
+    expect(without).not.toContain("<instrucciones_del_negocio>");
+    expect(without).not.toContain("{{INSTRUCCIONES}}");
+
+    // Espacios en blanco cuentan como "sin instrucciones":
+    const blank = renderSystemPrompt({ ...input, customInstructions: "   " });
+    expect(blank).not.toContain("<instrucciones_del_negocio>");
+  });
+
   it("inserts nichoPlaybook when provided and empty string when omitted", () => {
     const withPlaybook = renderSystemPrompt({
       ...input,


### PR DESCRIPTION
## El problema

Hoy la plantilla tiene **una sola forma** de agregarle una regla al bot (*"siempre ofrece agendar una cita al final"*, *"no des precios por chat"*): el campo del prompt manual — que **reemplaza el prompt completo**. Quien pega tres reglas ahí pierde el contexto del negocio, el playbook del giro, las instrucciones del KB y las reglas de seguridad, sin enterarse.

No es un error del usuario: **no existe alternativa aditiva**. El campo peligroso es el único campo.

Caso real: un bot en producción con campañas de Google Ads encendidas quedó casi una hora con 1,650 caracteres de reglas de estilo como único cerebro — y les ofreció a prospectos pagados un programa que el negocio ya había cancelado por escrito.

El PR #29 le pone la advertencia a ese campo. **Este PR construye la salida**: los dos se complementan, y ninguno depende del otro para mergearse (este no toca `config.ts`).

## Qué agrega

Un setting nuevo, `custom_instructions`, con la semántica opuesta al override — **se suma, nunca reemplaza**:

- **`db/settings.ts`** — la clave, comentada: *"Se SUMA al prompt generado; NO lo reemplaza (eso es `system_prompt_override`)"*.
- **`system-prompt.ts`** — bloque `<instrucciones_del_negocio>` en el template, espejo exacto del patrón de `<lecciones_aprendidas>` que ya existe. Vacío u omitido → no se renderiza nada.
- **`settings-loader.ts`** — la lee y la inyecta **solo al prompt generado**. Con un override manual activo no aplica — el override es "úsalo tal cual", misma semántica que ya tienen las lecciones del flywheel.
- **Panel (Mi Agente → cerebro)** — campo "✍️ Instrucciones" con badge **"se suman"**, colocado arriba del prompt manual, con la advertencia cruzada cuando hay un override activo: *"⚠ Tienes un prompt manual activo: estas instrucciones no aplican hasta que vuelvas al automático"*. Guardar vacío = quitarlas.
- **`routes.ts`** — el guardado en el modal del cerebro.

Detalle a propósito: el placeholder del campo es *"Ej. Siempre ofrece agendar una cita al final."* — el mismo ejemplo que hoy acompaña al campo del override en Configuración. Con este PR, ese ejemplo por fin tiene un lugar donde es seguro pegarlo.

## Decisiones tomadas (y por qué)

- **Solo afecta el prompt generado.** Un override manual dice "úsalo tal cual"; inyectarle cosas por atrás rompería esa promesa. Es la misma regla que ya siguen las lecciones (`settings-loader.ts` lo documenta desde antes: *"a manual override replaces the whole prompt, lessons included"*).
- **En `agente.ts`, no en `config.ts`** — para no chocar con el PR #29, que toca la vista de Configuración. Se mergean en cualquier orden.
- **Sin migración de esquema**: `settings` es key-value, la clave nueva no necesita DDL.

## Tests

4 nuevos:

- Las instrucciones aparecen en el prompt generado **y el resto del cerebro queda intacto** (`<role>`, `<business_context>`, `<anti_patterns>` siguen ahí — sumar, no reemplazar).
- Vacío o espacios → no se renderiza el bloque ni queda placeholder.
- **Con override activo, el prompt es el override tal cual** — las instrucciones no se cuelan.
- Render limpio en `renderSystemPrompt` con y sin instrucciones.

**Suite completa: 441 tests en verde. `tsc --noEmit` limpio.** Diff: 7 archivos, +90 líneas, cero eliminadas — no toca ningún comportamiento existente.
