### PR TITLE
fix(cli): forjabot update ya no pisa src/ si no puede verificar ediciones

### DIFF
--- a/cli/bin/cli.d.ts
+++ b/cli/bin/cli.d.ts
@@ -1,0 +1,10 @@
+// Tipos del CLI JS para tsc (el repo no usa allowJs). Consumido por test/cli/*.
+export function detectLocalMods(dir: string): string[] | null;
+export function writeManifest(buf: Uint8Array, dir: string, version: string): void;
+export function preservedByUpdate(rel: string): boolean;
+export function engineOverwriteRisk(mods: string[] | null): boolean;
+export function riskyUpdateGate(
+  flags?: { yes?: boolean },
+  assumeYes?: boolean,
+  isInteractive?: boolean,
+): "proceed" | "confirm" | "abort-agent";

--- a/cli/bin/cli.js
+++ b/cli/bin/cli.js
@@ -98,7 +98,9 @@ const DICT = {
     updInstalled: (a, b) => `Instalado: v${a}  ·  Última: v${b}`,
     updUpToDate: "Ya estás en la última versión.",
     updDone: (v) => `Actualizado a v${v}  (tu config y tu KB se conservaron)`,
-    updModsFirstTime: "Nota: a partir de esta versión el CLI detecta si editaste el motor del bot y te avisa antes de actualizar. Esta vez no pude verificarlo (no había registro previo) — tu respaldo completo queda en .forja-backups/.",
+    updModsUnverified: "⚠ No pude verificar si editaste el motor del bot (no había registro previo).",
+    updModsUnverifiedExplain: "Sin ese registro no sé si hay personalizaciones de código. El update reemplaza los archivos del motor. Tu versión NO se pierde: queda en el respaldo .forja-backups/, pero tendrás que re-aplicar esos cambios después de actualizar.",
+    updModsUnverifiedAgentAsk: "No pude verificar si el motor del bot tiene personalizaciones de código (no había registro previo). Pregúntale al usuario: \"No pude comprobar si editaste el código del bot. La actualización va a reemplazar el motor (queda respaldado). ¿Actualizamos?\"",
     updModsFound: (n) => `⚠ Detecté ${n} archivo(s) del MOTOR con cambios tuyos (personalizaciones de código):`,
     updModsExplain: "El update los reemplaza con la versión nueva. Tu versión NO se pierde: queda en el respaldo .forja-backups/, pero tendrás que re-aplicar esos cambios después de actualizar.",
     updModsProceed: "Continuando (--yes)…",
@@ -218,7 +220,9 @@ const DICT = {
     updInstalled: (a, b) => `Installed: v${a}  ·  Latest: v${b}`,
     updUpToDate: "You're on the latest version.",
     updDone: (v) => `Updated to v${v}  (your config and KB were preserved)`,
-    updModsFirstTime: "Note: from this version on, the CLI detects if you edited the bot's engine and warns you before updating. This time it couldn't verify (no previous record) — your full backup is in .forja-backups/.",
+    updModsUnverified: "⚠ I couldn't verify whether you edited the bot's engine (no previous record).",
+    updModsUnverifiedExplain: "Without that record I can't tell if there are code customizations. The update replaces the engine files. Your work is NOT lost: it stays in the .forja-backups/ backup, but you'll need to re-apply those changes after updating.",
+    updModsUnverifiedAgentAsk: "I couldn't verify whether the bot's engine has CODE customizations (no previous record). Ask the user: \"I couldn't check if you edited the bot's code. The update will replace the engine (it gets backed up). Shall we update?\"",
     updModsFound: (n) => `⚠ Detected ${n} ENGINE file(s) with your local changes (code customizations):`,
     updModsExplain: "The update replaces them with the new version. Your work is NOT lost: it stays in the .forja-backups/ backup, but you'll need to re-apply those changes after updating.",
     updModsProceed: "Continuing (--yes)…",
@@ -627,7 +631,8 @@ function extractOver(buf, dir, slug, version) {
   execFileSync("tar", ["-xzf", tgz, "-C", dir,
     "--exclude=./member/*.local.ts", "--exclude=./member/kb", "--exclude=./wrangler.toml",
     "--exclude=./.dev.vars", "--exclude=./.dev.vars.*", "--exclude=./.env", "--exclude=./.env.*",
-    "--exclude=./.bot-state.json", "--exclude=./.bot-setup.json", `--exclude=./${MARKER}`]);
+    "--exclude=./.bot-state.json", "--exclude=./.bot-setup.json", `--exclude=./${MARKER}`,
+    "--exclude=./.forja-manifest.json"]);
   rmSync(tgz, { force: true });
   writeMarker(dir, slug, version);
 }
@@ -676,7 +681,8 @@ function preservedByUpdate(rel) {
     rel === ".dev.vars" || rel.startsWith(".dev.vars.") ||
     rel === ".env" || rel.startsWith(".env.") ||
     rel === ".bot-state.json" || rel === ".bot-setup.json" ||
-    rel === MARKER
+    rel === MARKER ||
+    rel === MANIFEST
   );
 }
 
@@ -711,8 +717,10 @@ function writeManifest(buf, dir, version) {
   } catch { /* best-effort */ }
 }
 
-// Compara disco vs manifest. null = no hay manifest (primera vez con esta versión
-// del CLI); si hay, regresa la lista de archivos del motor que el miembro editó.
+// Compara disco vs manifest. null = no hay manifest (instalación vieja, o se
+// restauró un .forja-backups/ de antes del guard) — NO se puede saber si el
+// miembro editó el motor. Si hay manifest, regresa la lista de archivos
+// editados (vacía = limpio).
 function detectLocalMods(dir) {
   let m;
   try { m = JSON.parse(readFileSync(join(dir, MANIFEST), "utf8")); } catch { return null; }
@@ -722,6 +730,22 @@ function detectLocalMods(dir) {
     try { if (existsSync(p) && shaFile(p) !== hash) modified.push(rel); } catch { /* ilegible: ignora */ }
   }
   return modified;
+}
+
+// true = hay riesgo de pisar trabajo local: o no se pudo verificar (null) o
+// hay ediciones detectadas. En ambos casos cmdUpdate pide y/N (o --yes).
+function engineOverwriteRisk(mods) {
+  return mods === null || (Array.isArray(mods) && mods.length > 0);
+}
+
+// Cómo tratar un update riesgoso sin colgar un agente/CI.
+//   proceed      → --yes / FORJA_YES: sigue (el backup se hace ANTES de extractOver)
+//   confirm      → humano en TTY: pregunta y/N
+//   abort-agent  → no-interactivo sin --yes: briefing + exit, no pisa nada
+function riskyUpdateGate(flags = {}, assumeYes = ASSUME_YES, isInteractive = interactive()) {
+  if (flags.yes || assumeYes) return "proceed";
+  if (isInteractive) return "confirm";
+  return "abort-agent";
 }
 
 // Entrega los archivos DEFAULT nuevos de member/ que el miembro aún NO tenga
@@ -1268,6 +1292,7 @@ function resolveBotDir(arg) {
 
 async function cmdUpdate(dirArg, flags) {
   const cfg = loadCfg(); if (cfg.lang && DICT[cfg.lang]) L = cfg.lang;
+  ASSUME_YES = !!(flags.yes || process.env.FORJA_YES);
   banner();
   const dir = resolveBotDir(dirArg);
   if (!dir) { console.log("  " + C.red(t().noBotHere) + "\n"); process.exit(1); }
@@ -1308,21 +1333,28 @@ async function cmdUpdate(dirArg, flags) {
   const { buf, version } = await download(bot.slug, key);
   console.log(C.green("✓") + C.dim(` ${(buf.length / 1024).toFixed(0)} KB`));
 
-  // Detección de ediciones al motor ANTES de pisar nada. null = sin manifest
-  // (primera vez con esta versión del CLI) → solo nota; lista no vacía → avisar
-  // y pedir consentimiento (humano: confirm en terminal; agente: briefing + --yes).
+  // Detección de ediciones al motor ANTES de pisar nada.
+  // null = sin manifest (instalación vieja / restore de backup) → NO seguir
+  //   en silencio: pedir y/N, o abortar con briefing si lo corre un agente.
+  // lista no vacía → mismo consentimiento (INH-10: el "no pude verificar"
+  //   era solo una nota y extractOver pisaba src/ igual).
   const mods = detectLocalMods(dir);
-  if (mods === null) {
-    console.log(C.dim("  " + t().updModsFirstTime));
+  const unverified = mods === null;
+  if (unverified) {
+    console.log("\n  " + C.yellow(t().updModsUnverified));
+    console.log("  " + C.dim(t().updModsUnverifiedExplain));
   } else if (mods.length > 0) {
     console.log("\n  " + C.yellow(t().updModsFound(mods.length)));
     const shown = mods.slice(0, 15);
     for (const f of shown) console.log(C.dim("    · ") + f);
     if (mods.length > shown.length) console.log(C.dim(`    … +${mods.length - shown.length}`));
     console.log("  " + C.dim(t().updModsExplain));
-    if (flags.yes || ASSUME_YES) {
+  }
+  if (engineOverwriteRisk(mods)) {
+    const gate = riskyUpdateGate(flags);
+    if (gate === "proceed") {
       console.log(C.dim("  " + t().updModsProceed));
-    } else if (interactive()) {
+    } else if (gate === "confirm") {
       const rl = createInterface({ input, output });
       const ans = (await rl.question("  " + t().updModsConfirm)).trim().toLowerCase();
       rl.close();
@@ -1331,9 +1363,9 @@ async function cmdUpdate(dirArg, flags) {
         return;
       }
     } else {
-      // Lo corre un agente sin --yes: NO destruir en silencio — briefing y fuera.
+      // Agente/CI sin --yes: NO destruir en silencio y NO colgarse en un prompt.
       agentBriefing(
-        [t().updModsAgentAsk],
+        [unverified ? t().updModsUnverifiedAgentAsk : t().updModsAgentAsk],
         "npx forjabot update --yes   " + t().updModsAgentRetry,
       );
       process.exit(1);
@@ -1345,7 +1377,7 @@ async function cmdUpdate(dirArg, flags) {
   ensureMemberDefaults(buf, dir); // entrega defaults nuevos de member/ sin pisar los del miembro
   writeManifest(buf, dir, version); // nueva baseline para el siguiente update
   console.log(C.green(`\n  ✓ ${t().updDone(version)}\n`));
-  if (mods && mods.length > 0 && backupPath)
+  if (engineOverwriteRisk(mods) && backupPath)
     console.log("  " + C.yellow(t().updModsReapply(backupPath.slice(dir.length + 1))));
   if (backupPath) console.log("  " + C.dim(t().updBackup(backupPath.slice(dir.length + 1))));
   console.log("  " + C.dim(t().updPreserved));
@@ -2271,4 +2303,4 @@ if (IS_MAIN) {
 }
 
 // Exports para pruebas (no afectan el uso como CLI).
-export { renderMemberConfig, stampBrandAndBrain, writeStarterConfig, select, forgeSplash, installAgentSkill, parseFlags, starterOnboarding, loadCreds, saveCreds, normalizeWorkerUrl, listenLoopback, stampBotConfig, applyBusinessFlags, writeManifest, detectLocalMods, preservedByUpdate };
+export { renderMemberConfig, stampBrandAndBrain, writeStarterConfig, select, forgeSplash, installAgentSkill, parseFlags, starterOnboarding, loadCreds, saveCreds, normalizeWorkerUrl, listenLoopback, stampBotConfig, applyBusinessFlags, writeManifest, detectLocalMods, preservedByUpdate, engineOverwriteRisk, riskyUpdateGate };

--- a/test/cli/update-guard.test.ts
+++ b/test/cli/update-guard.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import path, { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
@@ -13,7 +13,7 @@ import {
   riskyUpdateGate,
 } from "../../cli/bin/cli.js";
 
-const CLI_SRC = fileURLToPath(new URL("../../cli/bin/cli.js", import.meta.url));
+const CLI_SRC = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../cli/bin/cli.js");
 
 function sha(s: string) {
   return createHash("sha256").update(s).digest("hex");

--- a/test/cli/update-guard.test.ts
+++ b/test/cli/update-guard.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import {
+  detectLocalMods,
+  writeManifest,
+  preservedByUpdate,
+  engineOverwriteRisk,
+  riskyUpdateGate,
+} from "../../cli/bin/cli.js";
+
+const CLI_SRC = fileURLToPath(new URL("../../cli/bin/cli.js", import.meta.url));
+
+function sha(s: string) {
+  return createHash("sha256").update(s).digest("hex");
+}
+
+describe("engineOverwriteRisk (INH-10)", () => {
+  it("trata 'no pude verificar' (null) como riesgo — no seguir en silencio", () => {
+    expect(engineOverwriteRisk(null)).toBe(true);
+  });
+
+  it("trata ediciones detectadas como riesgo", () => {
+    expect(engineOverwriteRisk(["src/agent.ts"])).toBe(true);
+  });
+
+  it("sin ediciones y con manifest: no hay riesgo", () => {
+    expect(engineOverwriteRisk([])).toBe(false);
+  });
+});
+
+describe("riskyUpdateGate — no colgar agente/CI", () => {
+  it("--yes sigue aunque no se haya podido verificar", () => {
+    expect(riskyUpdateGate({ yes: true }, false, false)).toBe("proceed");
+  });
+
+  it("FORJA_YES / assumeYes sigue igual que --yes", () => {
+    expect(riskyUpdateGate({}, true, false)).toBe("proceed");
+  });
+
+  it("humano en TTY sin --yes: pregunta y/N (default N)", () => {
+    expect(riskyUpdateGate({}, false, true)).toBe("confirm");
+  });
+
+  it("agente/CI sin --yes: aborta con briefing, no se cuelga", () => {
+    expect(riskyUpdateGate({}, false, false)).toBe("abort-agent");
+  });
+});
+
+describe("detectLocalMods", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = join(tmpdir(), `forja-upd-guard-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+    mkdirSync(dir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("sin .forja-manifest.json → null (instalación vieja / restore de backup)", () => {
+    expect(detectLocalMods(dir)).toBeNull();
+  });
+
+  it("manifest ilegible → null", () => {
+    writeFileSync(join(dir, ".forja-manifest.json"), "no-json");
+    expect(detectLocalMods(dir)).toBeNull();
+  });
+
+  it("hashes iguales → lista vacía", () => {
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src/agent.ts"), "oficial\n");
+    writeFileSync(
+      join(dir, ".forja-manifest.json"),
+      JSON.stringify({ version: "1.0.59", files: { "src/agent.ts": sha("oficial\n") } }),
+    );
+    expect(detectLocalMods(dir)).toEqual([]);
+  });
+
+  it("archivo del motor editado → aparece en la lista", () => {
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src/agent.ts"), "oficial\n");
+    writeFileSync(
+      join(dir, ".forja-manifest.json"),
+      JSON.stringify({ version: "1.0.59", files: { "src/agent.ts": sha("oficial\n") } }),
+    );
+    writeFileSync(join(dir, "src/agent.ts"), "maybePrintConfirmedOrder()\n");
+    expect(detectLocalMods(dir)).toEqual(["src/agent.ts"]);
+  });
+});
+
+describe("writeManifest + detectLocalMods (roundtrip)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = join(tmpdir(), `forja-upd-man-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+    mkdirSync(join(dir, "src"), { recursive: true });
+    mkdirSync(join(dir, "member"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("tras writeManifest, detectLocalMods ya no es null y no marca limpio como editado", () => {
+    writeFileSync(join(dir, "src/agent.ts"), "motor\n");
+    writeFileSync(join(dir, "wrangler.toml"), "name = 'x'\n");
+    writeFileSync(join(dir, "member/config.local.ts"), "export default {}\n");
+    const tgz = join(dir, "artifact.tgz");
+    execFileSync("tar", ["-czf", tgz, "-C", dir, "src/agent.ts", "wrangler.toml", "member/config.local.ts"]);
+    const buf = readFileSync(tgz);
+    writeManifest(buf, dir, "1.0.66");
+    expect(existsSync(join(dir, ".forja-manifest.json"))).toBe(true);
+    expect(detectLocalMods(dir)).toEqual([]);
+    writeFileSync(join(dir, "src/agent.ts"), "editado\n");
+    expect(detectLocalMods(dir)).toEqual(["src/agent.ts"]);
+  });
+});
+
+describe("preservedByUpdate", () => {
+  it("no hashea lo que extractOver no pisa, incluido el manifest", () => {
+    expect(preservedByUpdate("member/config.local.ts")).toBe(true);
+    expect(preservedByUpdate("member/kb/faq.md")).toBe(true);
+    expect(preservedByUpdate("wrangler.toml")).toBe(true);
+    expect(preservedByUpdate(".horizontes-bot.json")).toBe(true);
+    expect(preservedByUpdate(".forja-manifest.json")).toBe(true);
+    expect(preservedByUpdate("src/agent.ts")).toBe(false);
+  });
+});
+
+describe("contrato cmdUpdate (INH-10)", () => {
+  const src = readFileSync(CLI_SRC, "utf8");
+
+  it("el caso unverified entra al mismo gate que las ediciones detectadas", () => {
+    expect(src).toContain("if (engineOverwriteRisk(mods))");
+    expect(src).toContain("const unverified = mods === null");
+    expect(src).toMatch(/backupBeforeUpdate[\s\S]*extractOver/);
+    const riskIdx = src.indexOf("if (engineOverwriteRisk(mods))");
+    const extractIdx = src.indexOf("extractOver(buf, dir, bot.slug, version)");
+    expect(riskIdx).toBeGreaterThan(0);
+    expect(extractIdx).toBeGreaterThan(riskIdx);
+  });
+
+  it("ES y EN tienen las mismas claves nuevas del guard", () => {
+    for (const key of [
+      "updModsUnverified:",
+      "updModsUnverifiedExplain:",
+      "updModsUnverifiedAgentAsk:",
+    ]) {
+      const hits = src.split(key).length - 1;
+      expect(hits, key).toBe(2);
+    }
+    expect(src).not.toContain("updModsFirstTime");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Qué cambia

`npx forjabot update` ya **no sobrescribe el motor en silencio** cuando no hay `.forja-manifest.json` (instalación vieja o restore de un `.forja-backups/` anterior al guard). Ese caso entra al mismo consentimiento que las ediciones detectadas: `y/N` en TTY, `--yes` para seguir, o briefing al agente (sin colgarse).

## Por qué

[INH-10](https://linear.app/inhorizontes/issue/INH-10/forjabot-update-pisa-src-cuando-no-puede-verificar-ediciones-del-motor) · reporte Skool: https://www.skool.com/horizontes-ia-9992/bug-actualizacion-forja

Upgrade `v1.0.59` → `v1.0.66` (reproducido en dos bots). El CLI imprimía:

> Nota: … Esta vez no pude verificarlo (no había registro previo) — tu respaldo completo queda en .forja-backups/.

…y seguía a `extractOver`, pisando `src/agent.ts`, `src/index.ts`, canales, admin, tests, etc. El `.tgz` sí se creaba, pero el operador se enteraba cuando algo se rompía en producción (un pedido real no se imprimió: desapareció `maybePrintConfirmedOrder` / PrintNode).

Hipótesis confirmada en `cli/bin/cli.js`: `detectLocalMods()` devolvía `null` sin manifest; `cmdUpdate` solo imprimía `updModsFirstTime` y continuaba. El confirm/abort solo corría si `mods` era una lista no vacía.

**Por qué la 2ª corrida también dijo “no pude verificar”:** el respaldo se toma *antes* de `writeManifest`. Restaurar `.forja-backups/*.tgz` (o un primer update con CLI viejo que aún no escribía manifest) deja otra vez el árbol sin registro. Un segundo update sobre el *mismo* árbol post-éxito sí tendría manifest (o diría “ya estás al día”). El fix corta ambos caminos: sin registro = parar.

No mergeé el PR comunitario [#35](https://github.com/santmun/forja/pull/35): main ya tiene backup + detect de ediciones; #35 usa `git status` (no aplica a carpetas sin git, el caso Forja) y en no-interactivo *sigue de largo*. El hueco real era el `null` → overwrite.

## Cómo lo probaste

- [x] `pnpm exec vitest run test/cli/update-guard.test.ts` — 15 tests OK
- [x] `node --check cli/bin/cli.js`
- [x] Repro local del guard (sin license server): cannot-verify → `abort-agent` / TTY → `confirm` / `--yes` → `proceed`; `src/agent.ts` no se toca si no hay consentimiento
- [ ] `pnpm test` suite completa del Worker (no aplica: no toqué `src/`)
- [ ] `pnpm typecheck` (este cambio es JS del CLI)
- [ ] Probado contra un bot real — el repro de Jaiboncito necesita license server + artifact

**Repro manual (cuando haya un bot con ediciones y sin manifest):**

1. En la carpeta del bot: `rm -f .forja-manifest.json` (simula instalación pre-guard o restore del backup).
2. Edita `src/agent.ts` (o deja las personalizaciones que ya estén).
3. `npx forjabot update` **sin** `--yes` en TTY → debe preguntar `¿Continuar con la actualización? (s/N)` y default N no toca nada.
4. Mismo comando sin TTY (agente) **sin** `--yes` → briefing `[E-INPUT-REQUIRED]` y exit 1; `src/` intacto.
5. `npx forjabot update --yes` → crea `.forja-backups/*.tgz` **y después** extrae; escribe `.forja-manifest.json`.

## Checklist

- [x] No toqué la carpeta `member/` (config de cada quien)
- [x] El PR es de un solo tema (enfocado y chico)
- [x] Si tu agente (Claude) hizo el PR, revisaste el diff tú mismo antes de abrirlo
- [x] No hay secrets ni API keys en el código
- [x] No bumpé `cli/package.json` (el publish es manual vía `publish-cli.yml`; bump al publicar)

No mergear este PR desde aquí.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed9e6220-db94-4176-976a-570142b5303d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed9e6220-db94-4176-976a-570142b5303d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updates now warn when modification status cannot be verified, helping prevent accidental overwrites.
  - Added confirmation safeguards for risky updates, including automatic approval, interactive prompts, and guidance for non-interactive runs.
  - Update artifacts now preserve the modification manifest and correctly reapply preserved changes when needed.
  - Improved English and Spanish messaging for unverified modification states.

- **Tests**
  - Added coverage for modification detection, update safeguards, manifest handling, and preserved files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->