### PR TITLE
fix(cli): tar en Git Bash de Windows no trata C: como host remoto (INH-11)

### DIFF
--- a/cli/bin/cli.d.ts
+++ b/cli/bin/cli.d.ts
@@ -8,3 +8,20 @@ export function riskyUpdateGate(
   assumeYes?: boolean,
   isInteractive?: boolean,
 ): "proceed" | "confirm" | "abort-agent";
+export function gnuTarTreatsAsRemote(name: string): boolean;
+export function tarLocalPath(p: string, fromDir?: string): string;
+export function buildTarArchiveArgv(opts: {
+  op: string;
+  file: string;
+  extra?: string[];
+  forceLocal?: boolean;
+  fromDir?: string;
+}): string[];
+export function execTarArchive(
+  op: string,
+  archivePath: string,
+  extra?: string[],
+  execOpts?: { cwd?: string; encoding?: string },
+): string | Buffer;
+export function backupIsUsable(backupPath: string): boolean;
+export function backupBeforeUpdate(dir: string, fromVer: string): string | null;

--- a/cli/bin/cli.d.ts
+++ b/cli/bin/cli.d.ts
@@ -23,5 +23,5 @@ export function execTarArchive(
   extra?: string[],
   execOpts?: { cwd?: string; encoding?: string },
 ): string | Buffer;
-export function backupIsUsable(backupPath: string): boolean;
+export function backupIsUsable(backupPath: string | null | undefined): boolean;
 export function backupBeforeUpdate(dir: string, fromVer: string): string | null;

--- a/cli/bin/cli.js
+++ b/cli/bin/cli.js
@@ -23,7 +23,7 @@ import { stdin as input, stdout as output } from "node:process";
 import { mkdirSync, writeFileSync, readFileSync, rmSync, readdirSync, existsSync, statSync, realpathSync, chmodSync } from "node:fs";
 import { createServer } from "node:http";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, relative, dirname } from "node:path";
 import { execFileSync } from "node:child_process";
 import { randomUUID, createHash } from "node:crypto";
 import { fileURLToPath } from "node:url";
@@ -110,6 +110,8 @@ const DICT = {
     updModsAgentRetry: "(con su sí; tras actualizar, compara .forja-backups/ vs el motor nuevo y re-aplica sus personalizaciones)",
     updModsReapply: (p) => `⚠ Tus personalizaciones del motor quedaron en ${p} — compáralo contra el código nuevo y re-aplícalas antes de desplegar.`,
     updBackup: (p) => `Respaldé tu versión anterior en ${p} — por si quieres recuperar algo.`,
+    updBackupFailed: "No pude crear el respaldo. Por seguridad no actualicé nada (así no se pierde tu código).",
+    updBackupFailedHint: "Prueba el mismo comando desde PowerShell o cmd.exe. Si sigue fallando, avísanos en la comunidad.",
     updPreserved: "Se conservaron: tu configuración, tu base de conocimiento, tu wrangler.toml y lo que ajustaste en el panel o con /prompt.",
     updReplaced: "Se actualizó: el motor del bot (todo lo demás).",
     updGolden: "Recuerda: los cambios de comportamiento van en /prompt o tu config, NO en el código — así sobreviven a todos los updates.",
@@ -232,6 +234,8 @@ const DICT = {
     updModsAgentRetry: "(with their yes; after updating, diff .forja-backups/ vs the new engine and re-apply their customizations)",
     updModsReapply: (p) => `⚠ Your engine customizations were saved to ${p} — diff it against the new code and re-apply them before deploying.`,
     updBackup: (p) => `Backed up your previous version to ${p} — in case you want to recover anything.`,
+    updBackupFailed: "I couldn't create the backup. For safety I didn't update anything (so your code stays intact).",
+    updBackupFailedHint: "Try the same command from PowerShell or cmd.exe. If it still fails, tell us in the community.",
     updPreserved: "Preserved: your configuration, your knowledge base, your wrangler.toml, and anything you set in the panel or with /prompt.",
     updReplaced: "Updated: the bot's engine (everything else).",
     updGolden: "Remember: behavior changes go in /prompt or your config, NOT in the code — that way they survive every update.",
@@ -610,12 +614,109 @@ function stampBotConfig(dir, plan, slug) {
   s = s.replace(/bucket_name\s*=\s*"horizontes-bot-catalog[^"]*"/, `bucket_name = "horizontes-bot-catalog"`);
   writeFileSync(wt, s);
 }
+// ── tar seguro en Windows/Git Bash (INH-11) ──────────────────────────────────
+// GNU tar (Git-for-Windows/MSYS) trata `C:` en el nombre del archivo como host
+// remoto estilo rsync/ssh (`user@host:path`) → "Cannot connect to C: resolve
+// failed". El bsdtar de PowerShell/cmd no. Contrato: el operando de -f NUNCA
+// debe ser un nombre que GNU tar tome como remoto. Normalizamos a ruta
+// relativa con prefijo `./` y, si el binario es GNU tar, pasamos
+// `--force-local`. BSD tar (macOS) y el tar de Windows rechazan ese flag, así
+// que solo se agrega cuando `tar --version` dice "GNU tar".
+
+function gnuTarTreatsAsRemote(name) {
+  if (typeof name !== "string" || name === "") return false;
+  // GNU tar: si empieza con '/' o '.' es local, aunque tenga ':'.
+  if (name.charAt(0) === "/" || name.charAt(0) === ".") return false;
+  return name.includes(":");
+}
+
+function prefixDotSlash(rel) {
+  const s = String(rel).replace(/\\/g, "/");
+  if (s === "." || s === "..") return s;
+  if (s.startsWith("./") || s.startsWith("../")) return s;
+  return "./" + s;
+}
+
+/** Relativo win→win (también en tests Linux con strings `C:\...`). Misma unidad o null. */
+function windowsRelative(fromDir, p) {
+  const fromWin = String(fromDir).match(/^([A-Za-z]):[\\/](.*)$/);
+  const pWin = String(p).match(/^([A-Za-z]):[\\/](.*)$/);
+  if (!fromWin || !pWin) return null;
+  if (fromWin[1].toLowerCase() !== pWin[1].toLowerCase()) return null;
+  const fromParts = fromWin[2].split(/[\\/]/).filter(Boolean);
+  const pParts = pWin[2].split(/[\\/]/).filter(Boolean);
+  let i = 0;
+  while (i < fromParts.length && i < pParts.length && fromParts[i].toLowerCase() === pParts[i].toLowerCase()) i++;
+  return [...Array(fromParts.length - i).fill(".."), ...pParts.slice(i)].join("/") || ".";
+}
+
+function tarLocalPath(p, fromDir = process.cwd()) {
+  if (typeof p !== "string" || p === "") return p;
+  const winRel = windowsRelative(fromDir, p);
+  if (winRel != null) return prefixDotSlash(winRel);
+  // Ya es relativa y GNU tar no la toma como remota: solo unifica slashes + `./`.
+  if (!gnuTarTreatsAsRemote(p) && !p.startsWith("/") && !/^[A-Za-z]:/.test(p)) {
+    return prefixDotSlash(p);
+  }
+  try {
+    const rel = relative(fromDir, p);
+    if (rel !== "" && !gnuTarTreatsAsRemote(rel) && !/^[A-Za-z]:/.test(rel)) {
+      return prefixDotSlash(rel);
+    }
+  } catch { /* fromDir/p incompatibles entre plataformas */ }
+  if (!gnuTarTreatsAsRemote(p)) return String(p).replace(/\\/g, "/");
+  return "./" + String(p).replace(/\\/g, "/");
+}
+
+function buildTarArchiveArgv({ op, file, extra = [], forceLocal = false, fromDir }) {
+  const local = tarLocalPath(file, fromDir ?? process.cwd());
+  const argv = [];
+  if (forceLocal) argv.push("--force-local");
+  argv.push(op, local, ...extra);
+  return argv;
+}
+
+let _tarIsGnu;
+function isGnuTar() {
+  if (_tarIsGnu !== undefined) return _tarIsGnu;
+  try {
+    const out = execFileSync("tar", ["--version"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5000,
+    });
+    _tarIsGnu = /GNU tar/i.test(out);
+  } catch {
+    _tarIsGnu = false;
+  }
+  return _tarIsGnu;
+}
+
+function execTarArchive(op, archivePath, extra = [], execOpts = {}) {
+  const fromDir = execOpts.cwd || dirname(archivePath);
+  const argv = buildTarArchiveArgv({
+    op,
+    file: archivePath,
+    extra,
+    fromDir,
+    forceLocal: isGnuTar(),
+  });
+  return execFileSync("tar", argv, { ...execOpts, cwd: fromDir });
+}
+
+/** Fail-closed: sin respaldo usable no se pisa src/ (INH-11). */
+function backupIsUsable(backupPath) {
+  if (typeof backupPath !== "string" || !backupPath) return false;
+  try { return existsSync(backupPath) && statSync(backupPath).size > 0; }
+  catch { return false; }
+}
+
 function extractFresh(buf, slug, version) {
   const dir = join(process.cwd(), slug);
   mkdirSync(dir, { recursive: true });
   const tgz = join(dir, ".artifact.tgz");
   writeFileSync(tgz, buf);
-  execFileSync("tar", ["-xzf", tgz, "-C", dir]);
+  execTarArchive("-xzf", tgz, [], { cwd: dir });
   rmSync(tgz, { force: true });
   writeMarker(dir, slug, version);
   writeManifest(buf, dir, version); // baseline para detectar ediciones al motor en updates
@@ -628,11 +729,12 @@ function extractFresh(buf, slug, version) {
 function extractOver(buf, dir, slug, version) {
   const tgz = join(dir, ".artifact.tgz");
   writeFileSync(tgz, buf);
-  execFileSync("tar", ["-xzf", tgz, "-C", dir,
+  execTarArchive("-xzf", tgz, [
     "--exclude=./member/*.local.ts", "--exclude=./member/kb", "--exclude=./wrangler.toml",
     "--exclude=./.dev.vars", "--exclude=./.dev.vars.*", "--exclude=./.env", "--exclude=./.env.*",
     "--exclude=./.bot-state.json", "--exclude=./.bot-setup.json", `--exclude=./${MARKER}`,
-    "--exclude=./.forja-manifest.json"]);
+    "--exclude=./.forja-manifest.json",
+  ], { cwd: dir });
   rmSync(tgz, { force: true });
   writeMarker(dir, slug, version);
 }
@@ -640,26 +742,30 @@ function extractOver(buf, dir, slug, version) {
 // P0 — respaldo automático ANTES de traer el motor nuevo: snapshot .tgz de la carpeta
 // del bot para que el miembro nunca pierda ediciones (aunque las haya hecho en el
 // código del motor, no solo en member/). Es tar (no git): funciona en Mac/Linux/Windows
-// sin setup ni auth. Nunca bloquea el update: si algo falla, devuelve null y seguimos.
+// sin setup ni auth. Si no se puede escribir el respaldo, devolvemos null — el update
+// DEBE abortar (fail-closed) antes de extractOver: un backup fallido + extract es
+// cómo un usuario de Windows puede perder src/ (INH-11).
 function backupBeforeUpdate(dir, fromVer) {
   const stamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19); // 2026-08-15T14-30-05
   const backDir = join(dir, ".forja-backups");
   const dest = join(backDir, `${stamp}_v${fromVer}.tgz`);
   try {
     mkdirSync(backDir, { recursive: true });
-    // -C dir + "." archiva todo; los --exclude evitan node_modules, el propio backup y git.
-    execFileSync("tar", ["-czf", dest, "-C", dir,
+    // cwd=dir + "." archiva todo; los --exclude evitan node_modules, el propio backup y git.
+    execTarArchive("-czf", dest, [
       "--exclude=./node_modules", "--exclude=./.forja-backups",
       "--exclude=./.git", "--exclude=./.wrangler",
       // NO archivar secretos: el update nunca los pisa, así que no hay nada que respaldar,
       // y así el .tgz jamás contiene llaves (importante si algún día se sube a GitHub).
       "--exclude=./.dev.vars", "--exclude=./.dev.vars.*",
-      "--exclude=./.env", "--exclude=./.env.*", "."]);
+      "--exclude=./.env", "--exclude=./.env.*", ".",
+    ], { cwd: dir });
     // Hygiene: conserva solo los 5 respaldos más recientes (stamp ISO ⇒ orden lexical = cronológico).
     try {
       const olds = readdirSync(backDir).filter((f) => f.endsWith(".tgz")).sort();
       for (const f of olds.slice(0, -5)) rmSync(join(backDir, f), { force: true });
     } catch { /* pruning best-effort */ }
+    if (!backupIsUsable(dest)) return null;
     return dest;
   } catch { return null; }
 }
@@ -695,7 +801,7 @@ function artifactEntries(buf, dir) {
   const tgz = join(dir, ".artifact-ls.tgz");
   writeFileSync(tgz, buf);
   try {
-    const out = execFileSync("tar", ["-tzf", tgz], { encoding: "utf8" });
+    const out = execTarArchive("-tzf", tgz, [], { cwd: dir, encoding: "utf8" });
     return out.split("\n")
       .map((l) => l.trim().replace(/^\.\//, ""))
       .filter((l) => l && !l.endsWith("/"));
@@ -765,7 +871,7 @@ function ensureMemberDefaults(buf, dir) {
     // garantiza), así que no hay nada que pisar. NADA de --skip-old-files: es un
     // flag solo-GNU y el tar de macOS (BSD) lo rechaza → el update fallaba callado
     // en Mac y el stub nunca se creaba (reportado por Pedro/PeeterDigital).
-    execFileSync("tar", ["-xzf", tgz, "-C", dir, ...missing]);
+    execTarArchive("-xzf", tgz, missing, { cwd: dir });
   } catch { /* si el tarball no lo trae (artifact viejo), no rompemos el update */ }
   rmSync(tgz, { force: true });
 }
@@ -1373,6 +1479,12 @@ async function cmdUpdate(dirArg, flags) {
   }
 
   const backupPath = backupBeforeUpdate(dir, marker.version);  // P0: respaldo ANTES de sobrescribir
+  if (!backupIsUsable(backupPath)) {
+    console.log("\n  " + C.red("✗ " + t().updBackupFailed));
+    console.log("  " + C.dim(t().updBackupFailedHint));
+    console.log(C.dim("  " + supportLine() + "\n"));
+    process.exit(1);
+  }
   extractOver(buf, dir, bot.slug, version);
   ensureMemberDefaults(buf, dir); // entrega defaults nuevos de member/ sin pisar los del miembro
   writeManifest(buf, dir, version); // nueva baseline para el siguiente update
@@ -2303,4 +2415,4 @@ if (IS_MAIN) {
 }
 
 // Exports para pruebas (no afectan el uso como CLI).
-export { renderMemberConfig, stampBrandAndBrain, writeStarterConfig, select, forgeSplash, installAgentSkill, parseFlags, starterOnboarding, loadCreds, saveCreds, normalizeWorkerUrl, listenLoopback, stampBotConfig, applyBusinessFlags, writeManifest, detectLocalMods, preservedByUpdate, engineOverwriteRisk, riskyUpdateGate };
+export { renderMemberConfig, stampBrandAndBrain, writeStarterConfig, select, forgeSplash, installAgentSkill, parseFlags, starterOnboarding, loadCreds, saveCreds, normalizeWorkerUrl, listenLoopback, stampBotConfig, applyBusinessFlags, writeManifest, detectLocalMods, preservedByUpdate, engineOverwriteRisk, riskyUpdateGate, gnuTarTreatsAsRemote, tarLocalPath, buildTarArchiveArgv, execTarArchive, backupIsUsable, backupBeforeUpdate };

--- a/test/cli/tar-paths.test.ts
+++ b/test/cli/tar-paths.test.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck — el CLI publicado es un JS sin .d.ts; el contrato se afirma en runtime.
 import { describe, it, expect } from "vitest";
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync, statSync } from "node:fs";
 import { join } from "node:path";
@@ -155,8 +154,8 @@ describe("buildTarArchiveArgv — path-normalization / force-local contract", ()
 
 describe("backupIsUsable (fail-closed before extractOver)", () => {
   it("rejects null/empty/missing so update must abort", () => {
-    expect(backupIsUsable(null as unknown as string)).toBe(false);
-    expect(backupIsUsable(undefined as unknown as string)).toBe(false);
+    expect(backupIsUsable(null)).toBe(false);
+    expect(backupIsUsable(undefined)).toBe(false);
     expect(backupIsUsable("")).toBe(false);
     expect(backupIsUsable("/definitely/not/a/backup.tgz")).toBe(false);
   });

--- a/test/cli/tar-paths.test.ts
+++ b/test/cli/tar-paths.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import {
+  gnuTarTreatsAsRemote,
+  tarLocalPath,
+  buildTarArchiveArgv,
+  execTarArchive,
+  backupIsUsable,
+  backupBeforeUpdate,
+} from "../../cli/bin/cli.js";
+
+// Rutas del reporte INH-11 (Adrián, Git Bash, v1.0.59 → v1.0.66).
+const BOT = "C:\\Users\\leofl\\OneDrive\\Documentos\\CHATBOT\\starter";
+const ARTIFACT = `${BOT}\\.artifact.tgz`;
+const BACKUP = `${BOT}\\.forja-backups\\2026-08-24T20-57-49_v1.0.59.tgz`;
+const LIST = `${BOT}\\.artifact-ls.tgz`;
+
+function fileOperand(argv: string[]): string {
+  const i = argv.findIndex((a) => a === "-xzf" || a === "-czf" || a === "-tzf");
+  if (i < 0) throw new Error("missing tar -f op");
+  return argv[i + 1];
+}
+
+describe("gnuTarTreatsAsRemote (INH-11 / Git Bash GNU tar)", () => {
+  it("treats a Windows drive-letter archive as a remote host (the reported bug)", () => {
+    expect(gnuTarTreatsAsRemote(ARTIFACT)).toBe(true);
+    expect(gnuTarTreatsAsRemote(BACKUP)).toBe(true);
+    expect(gnuTarTreatsAsRemote("C:/Users/leofl/foo.tgz")).toBe(true);
+    expect(gnuTarTreatsAsRemote("C:not-a-host.tgz")).toBe(true);
+  });
+
+  it("does not treat names that start with / or . as remote (GNU tar rule)", () => {
+    expect(gnuTarTreatsAsRemote("./.artifact.tgz")).toBe(false);
+    expect(gnuTarTreatsAsRemote("./.forja-backups/x.tgz")).toBe(false);
+    expect(gnuTarTreatsAsRemote("/c/Users/leofl/foo.tgz")).toBe(false);
+    expect(gnuTarTreatsAsRemote("../foo.tgz")).toBe(false);
+    expect(gnuTarTreatsAsRemote(".")).toBe(false);
+  });
+
+  it("does not treat a colon-free relative name as remote", () => {
+    expect(gnuTarTreatsAsRemote(".artifact.tgz")).toBe(false);
+    expect(gnuTarTreatsAsRemote("foo.tgz")).toBe(false);
+  });
+});
+
+describe("tarLocalPath", () => {
+  it("turns the reporter's absolute Windows paths into ./relative names", () => {
+    expect(tarLocalPath(ARTIFACT, BOT)).toBe("./.artifact.tgz");
+    expect(tarLocalPath(BACKUP, BOT)).toBe("./.forja-backups/2026-08-24T20-57-49_v1.0.59.tgz");
+    expect(tarLocalPath(LIST, BOT)).toBe("./.artifact-ls.tgz");
+  });
+
+  it("accepts forward-slash Windows paths and is case-insensitive on the drive", () => {
+    expect(tarLocalPath("C:/Users/leofl/OneDrive/Documentos/CHATBOT/starter/.artifact.tgz", BOT))
+      .toBe("./.artifact.tgz");
+    expect(tarLocalPath(
+      "c:\\Users\\leofl\\OneDrive\\Documentos\\CHATBOT\\starter\\.artifact.tgz",
+      BOT,
+    )).toBe("./.artifact.tgz");
+  });
+
+  it("walks up with ../ when the archive is outside fromDir", () => {
+    expect(tarLocalPath(`${BOT}\\.artifact.tgz`, `${BOT}\\member`)).toBe("../.artifact.tgz");
+  });
+
+  it("prefixes ./C:/... when drives differ (GNU tar then sees a leading dot)", () => {
+    const other = tarLocalPath("D:\\other\\x.tgz", BOT);
+    expect(other.startsWith(".")).toBe(true);
+    expect(gnuTarTreatsAsRemote(other)).toBe(false);
+  });
+
+  it("normalized result is never a GNU-tar remote name", () => {
+    for (const file of [ARTIFACT, BACKUP, LIST, "C:not-a-host.tgz"]) {
+      expect(gnuTarTreatsAsRemote(tarLocalPath(file, BOT))).toBe(false);
+    }
+  });
+
+  it("leaves POSIX relative names safe", () => {
+    expect(gnuTarTreatsAsRemote(tarLocalPath(".artifact.tgz", "/tmp/bot"))).toBe(false);
+    expect(tarLocalPath("/tmp/bot/.artifact.tgz", "/tmp/bot")).toBe("./.artifact.tgz");
+  });
+});
+
+describe("buildTarArchiveArgv — path-normalization / force-local contract", () => {
+  const extractExtra = [
+    "--exclude=./member/*.local.ts", "--exclude=./member/kb", "--exclude=./wrangler.toml",
+    "--exclude=./.dev.vars", "--exclude=./.dev.vars.*", "--exclude=./.env", "--exclude=./.env.*",
+    "--exclude=./.bot-state.json", "--exclude=./.bot-setup.json", "--exclude=./.horizontes-bot.json",
+  ];
+
+  it("extractOver argv: --force-local + relative archive (Git Bash GNU tar)", () => {
+    const argv = buildTarArchiveArgv({
+      op: "-xzf",
+      file: ARTIFACT,
+      extra: extractExtra,
+      forceLocal: true,
+      fromDir: BOT,
+    });
+    expect(argv[0]).toBe("--force-local");
+    expect(argv[1]).toBe("-xzf");
+    expect(fileOperand(argv)).toBe("./.artifact.tgz");
+    expect(gnuTarTreatsAsRemote(fileOperand(argv))).toBe(false);
+    expect(argv.join("\0")).not.toMatch(/(^|\0)[A-Za-z]:/);
+  });
+
+  it("extractOver argv without --force-local stays safe (BSD tar / Windows bsdtar)", () => {
+    const argv = buildTarArchiveArgv({
+      op: "-xzf",
+      file: ARTIFACT,
+      extra: extractExtra,
+      forceLocal: false,
+      fromDir: BOT,
+    });
+    expect(argv[0]).toBe("-xzf");
+    expect(argv).not.toContain("--force-local");
+    expect(fileOperand(argv)).toBe("./.artifact.tgz");
+    expect(gnuTarTreatsAsRemote(fileOperand(argv))).toBe(false);
+  });
+
+  it("backupBeforeUpdate argv uses a relative dest under .forja-backups/", () => {
+    const argv = buildTarArchiveArgv({
+      op: "-czf",
+      file: BACKUP,
+      extra: ["--exclude=./node_modules", "--exclude=./.forja-backups", "."],
+      forceLocal: true,
+      fromDir: BOT,
+    });
+    expect(fileOperand(argv)).toBe("./.forja-backups/2026-08-24T20-57-49_v1.0.59.tgz");
+    expect(gnuTarTreatsAsRemote(fileOperand(argv))).toBe(false);
+  });
+
+  it("artifactEntries / writeManifest listing argv is local", () => {
+    const argv = buildTarArchiveArgv({
+      op: "-tzf",
+      file: LIST,
+      forceLocal: true,
+      fromDir: BOT,
+    });
+    expect(fileOperand(argv)).toBe("./.artifact-ls.tgz");
+    expect(gnuTarTreatsAsRemote(fileOperand(argv))).toBe(false);
+  });
+
+  it("never puts a raw C: archive name in argv (the Git Bash failure mode)", () => {
+    for (const op of ["-xzf", "-czf", "-tzf"] as const) {
+      const argv = buildTarArchiveArgv({ op, file: ARTIFACT, fromDir: BOT, forceLocal: true });
+      expect(argv.some((a) => /^[A-Za-z]:/.test(a))).toBe(false);
+      expect(gnuTarTreatsAsRemote(fileOperand(argv))).toBe(false);
+    }
+  });
+});
+
+describe("backupIsUsable (fail-closed before extractOver)", () => {
+  it("rejects null/empty/missing so update must abort", () => {
+    expect(backupIsUsable(null as unknown as string)).toBe(false);
+    expect(backupIsUsable(undefined as unknown as string)).toBe(false);
+    expect(backupIsUsable("")).toBe(false);
+    expect(backupIsUsable("/definitely/not/a/backup.tgz")).toBe(false);
+  });
+
+  it("accepts a non-empty file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "forja-bak-"));
+    const p = join(dir, "ok.tgz");
+    writeFileSync(p, "not-empty");
+    expect(backupIsUsable(p)).toBe(true);
+    writeFileSync(p, "");
+    expect(backupIsUsable(p)).toBe(false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+function tarIsGnu(): boolean {
+  try {
+    return /GNU tar/i.test(execFileSync("tar", ["--version"], { encoding: "utf8" }));
+  } catch {
+    return false;
+  }
+}
+
+describe("execTarArchive + backupBeforeUpdate (real tar on this host)", () => {
+  it.skipIf(!tarIsGnu())("reproduces GNU tar 'Cannot connect to C:' and shows the helper argv succeeds", () => {
+    const dir = mkdtempSync(join(tmpdir(), "forja-repro-"));
+    try {
+      writeFileSync(join(dir, "f.txt"), "x\n");
+      try {
+        execFileSync("tar", ["-czf", "C:not-a-host.tgz", "-C", dir, "f.txt"], { encoding: "utf8" });
+        expect.fail("GNU tar should have treated C: as a remote host");
+      } catch (err) {
+        expect(String((err as { stderr?: Buffer }).stderr || err)).toMatch(/Cannot connect to C:/);
+      }
+      const argv = buildTarArchiveArgv({
+        op: "-czf",
+        file: join(dir, "ok.tgz"),
+        extra: ["f.txt"],
+        forceLocal: true,
+        fromDir: dir,
+      });
+      execFileSync("tar", argv, { cwd: dir });
+      expect(existsSync(join(dir, "ok.tgz"))).toBe(true);
+      expect(statSync(join(dir, "ok.tgz")).size).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("creates and lists an archive using only local names", () => {
+    const dir = mkdtempSync(join(tmpdir(), "forja-tar-"));
+    writeFileSync(join(dir, "hello.txt"), "hola\n");
+    const dest = join(dir, "out.tgz");
+    execTarArchive("-czf", dest, ["hello.txt"], { cwd: dir });
+    expect(existsSync(dest)).toBe(true);
+    expect(statSize(dest)).toBeGreaterThan(0);
+    const listing = String(execTarArchive("-tzf", dest, [], { cwd: dir, encoding: "utf8" }));
+    expect(listing).toContain("hello.txt");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("backupBeforeUpdate writes a usable .tgz (so fail-closed would let extractOver proceed)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "forja-upd-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "agent.ts"), "export {}\n");
+    const dest = backupBeforeUpdate(dir, "1.0.59");
+    expect(dest).toBeTruthy();
+    expect(backupIsUsable(dest)).toBe(true);
+    const listing = execFileSync("tar", ["-tzf", dest as string], { encoding: "utf8" });
+    expect(listing).toMatch(/src\/agent\.ts/);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+function statSize(p: string): number {
+  return statSync(p).size;
+}

--- a/test/cli/tar-paths.test.ts
+++ b/test/cli/tar-paths.test.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck — el CLI publicado es un JS sin .d.ts; el contrato se afirma en runtime.
 import { describe, it, expect } from "vitest";
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync, statSync } from "node:fs";
 import { join } from "node:path";
@@ -146,7 +147,7 @@ describe("buildTarArchiveArgv — path-normalization / force-local contract", ()
   it("never puts a raw C: archive name in argv (the Git Bash failure mode)", () => {
     for (const op of ["-xzf", "-czf", "-tzf"] as const) {
       const argv = buildTarArchiveArgv({ op, file: ARTIFACT, fromDir: BOT, forceLocal: true });
-      expect(argv.some((a) => /^[A-Za-z]:/.test(a))).toBe(false);
+      expect(argv.some((a: string) => /^[A-Za-z]:/.test(a))).toBe(false);
       expect(gnuTarTreatsAsRemote(fileOperand(argv))).toBe(false);
     }
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Qué cambia

El CLI ya no pasa rutas `C:\...` crudas a `tar`. Todas las llamadas (`extractOver`, `extractFresh`, `backupBeforeUpdate`, `artifactEntries` / `writeManifest`, `ensureMemberDefaults`) van por un helper que:

1. **Normaliza** el archivo `-f` a una ruta relativa con prefijo `./` (GNU tar no toma como remoto un nombre que empieza con `.`).
2. Agrega **`--force-local` solo si `tar --version` dice GNU tar**. BSD tar (macOS) y el bsdtar de Windows rechazan ese flag; el workaround confirmado (PowerShell / cmd.exe) se conserva.
3. Si el respaldo no se puede escribir, el update **aborta antes de `extractOver`** (fail-closed). Un backup fallido + extract es cómo un usuario de Windows puede perder `src/`.

**Rebase:** esta rama quedó rebaseada sobre `main` @ `f393528` (INH-10 squash-merge, PR #53). `cmdUpdate` tiene **las dos** protecciones:

- INH-10: `engineOverwriteRisk` / `riskyUpdateGate` / manifest no verificado bloquea el overwrite silencioso.
- INH-11: `backupIsUsable` aborta si el `.tgz` de respaldo no se pudo escribir.

Se conservan `test/cli/update-guard.test.ts` (main) y `test/cli/tar-paths.test.ts` (esta rama). Exports de ambos. No se subió `cli/package.json`. **No mergear desde este agente. No publicar el paquete.**

## Por qué

Linear: [INH-11](https://linear.app/inhorizontes/issue/INH-11/forjabot-update-tar-rompe-en-git-bash-de-windows-c-como-host-remoto)
Skool: [bug-actualizacion-forja](https://www.skool.com/horizontes-ia-9992/bug-actualizacion-forja)
Reporter: Adrián Leonardo Sánchez Santana · Windows · `C:\Users\leofl\OneDrive\Documentos\CHATBOT\starter` · v1.0.59 → v1.0.66.

Desde Git Bash:

```
tar (child): Cannot connect to C: resolve failed
tar: C\:\\Users\\...\\.forja-backups\\....tgz: Cannot write: Broken pipe
Error: Command failed: tar -xzf C:\Users\...\.artifact.tgz -C C:\Users\...
    at extractOver (.../forjabot/bin/cli.js)
```

Causa: `execFileSync("tar", ...)` con rutas Windows. El GNU tar de Git-for-Windows/MSYS interpreta `C:` como host remoto (estilo rsync/ssh), no como letra de unidad. El mismo comando en PowerShell/cmd (bsdtar de Windows) funciona.

## Cómo lo probaste

- [x] Tests del contrato path-normalization / force-local en `test/cli/tar-paths.test.ts`
- [x] Tests del update-guard INH-10 en `test/cli/update-guard.test.ts` (siguen pasando)
- [x] `pnpm test` pasa — 74 files / 521 tests (post-rebase sobre INH-10)
- [x] `pnpm typecheck` limpio
- [ ] (si aplica) probado contra un bot real — no; este agente no publica ni corre Git Bash en Windows

## Checklist

- [x] No toqué la carpeta `member/` (config de cada quien)
- [x] El PR es de un solo tema (enfocado y chico)
- [ ] Si tu agente (Claude) hizo el PR, revisaste el diff tú mismo antes de abrirlo
- [x] No hay secrets ni API keys en el código
- [x] No se bumpeó `cli/package.json`
- [x] INH-10 en main no se revirtió; el gate y el abort de backup conviven

## Nota para quien revise

**No mergear este PR desde el agente.** Revisar el diff a mano y decidir el publish del CLI (versión) en un paso aparte.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-520fcd1a-9b03-429f-b4db-43b43399ad8f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-520fcd1a-9b03-429f-b4db-43b43399ad8f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

