### PR TITLE
chore(cli): bump forjabot a 1.1.39

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forjabot",
-  "version": "1.1.38",
+  "version": "1.1.39",
   "description": "Forja — instala bots de IA en tu propia infraestructura, en un comando. Las piezas las ponemos nosotros; tu agente las arma. Por Horizontes IA.",
   "license": "MIT",
   "author": "Horizontes IA (Santiago Muñoz) <contacto@innovandohorizontes.com>",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Qué cambia
Sube `forjabot` de `1.1.38` a `1.1.39` en `cli/package.json` para publicar en npm el fix de OpenAI Chat Completions que ya está en `main` (PR #58, `5c8e5b9`).

## Por qué
Santi pidió publicar el PR 58. El workflow de Trusted Publishing (`publish-cli.yml`) publica la versión que está en el commit; sin este bump publicaría de nuevo `1.1.38`.

## Cómo lo probaste
- [x] El bump anterior (`810d580` / PR #56, 1.1.37) solo tocó `cli/package.json` — misma convención
- [x] No hay changelog ni lockfile que referencie la versión del CLI
- [x] `1.1.39` no está tomado en npm (`npm view forjabot version` → `1.1.38`)
- [ ] `pnpm test` / `pnpm typecheck` — no aplica (un solo cambio de versión, sin código)
- [x] CI `test` + CodeRabbit en verde antes del merge

## Checklist
- [x] No toqué la carpeta `member/`
- [x] El PR es de un solo tema (bump de versión)
- [x] Diff revisado: una línea en `cli/package.json`
- [x] No hay secrets ni API keys
- [x] No toqué forja-cloud ni archivos ajenos
- [x] Los demás PRs abiertos (#35 #34 #28 #27 #23 #22 #21 #19 #18 #17 #13 #7 #4) no se tocaron

## Estado
**Merged** en `main` como `54e5e35`.

**Publish bloqueado:** `gh workflow run publish-cli.yml --repo santmun/forja` falló con HTTP 403 (`Resource not accessible by integration`). El token de este agente no tiene `actions:write`. No se publicó desde la VM. npm sigue en `1.1.38`.

Santi: dispara el workflow a mano en https://github.com/santmun/forja/actions/workflows/publish-cli.yml (branch `main`, commit `54e5e35`) para publicar `forjabot@1.1.39` vía OIDC Trusted Publishing.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b47b02e4-f9d8-41e8-bd5d-5206a3d9e48e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b47b02e4-f9d8-41e8-bd5d-5206a3d9e48e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CLI package version to 1.1.39.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->