### PR TITLE
fix(agent): tope de 20 min en pausa por takeover del dueño

### DIFF
--- a/src/admin/routes.ts
+++ b/src/admin/routes.ts
@@ -49,7 +49,7 @@ import { sendCampaign, createHandoffTemplate, contentApprovalStatus } from "../c
 import { Db } from "../db/client";
 import { LeadsRepo, type Lead } from "../db/leads";
 import { TicketsRepo } from "../db/tickets";
-import { ConversationsRepo } from "../db/conversations";
+import { ConversationsRepo, OWNER_TAKEOVER_MS } from "../db/conversations";
 import { MessagesRepo } from "../db/messages";
 import { SettingsRepo, SETTING_KEYS, type SettingKey } from "../db/settings";
 import { CONTROLS, levelToValue } from "./control-levels";
@@ -544,14 +544,12 @@ adminApp.post("/tickets/:id/resolve", async (c) => {
 
 // --- Inbox actions (F1) -------------------------------------------------------
 
-/** Owner takes over for this long after replying/pausing from the dashboard. */
-const TAKEOVER_MS = 60 * 60 * 1000;
-
 // Reply AS A HUMAN from the dashboard: sends through the conversation's channel
 // adapter (Twilio/Telegram/Meta/ManyChat), persists the message as role=owner,
-// and pauses the bot (owner takeover — same behavior as isOwnerMessage in the
-// agent). Returns a status line for #send-status plus an out-of-band swap that
-// refreshes #thread-live instantly. X-Sent: 1 tells the composer to reset.
+// and pauses the bot (owner takeover — same 20-min sliding window as
+// isOwnerMessage in the agent). Returns a status line for #send-status plus
+// an out-of-band swap that refreshes #thread-live instantly. X-Sent: 1 tells
+// the composer to reset.
 adminApp.post("/conversations/:id/reply", async (c) => {
   const id = c.req.param("id");
   const form = await c.req.formData().catch(() => null);
@@ -583,7 +581,7 @@ adminApp.post("/conversations/:id/reply", async (c) => {
   const msgs = new MessagesRepo(db);
   await msgs.append(id, "owner", text);
   await convs.touchLastMessage(id);
-  await convs.setPausedUntil(id, Date.now() + TAKEOVER_MS);
+  await convs.setPausedUntil(id, Date.now() + OWNER_TAKEOVER_MS);
 
   c.header("X-Sent", "1");
   return c.html(
@@ -597,7 +595,7 @@ adminApp.post("/conversations/:id/reply", async (c) => {
 adminApp.post("/conversations/:id/pause", async (c) => {
   const id = c.req.param("id");
   const convs = new ConversationsRepo(new Db(c.env.DB));
-  await convs.setPausedUntil(id, Date.now() + TAKEOVER_MS);
+  await convs.setPausedUntil(id, Date.now() + OWNER_TAKEOVER_MS);
   return c.html(await renderThreadLive(c.env, id));
 });
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -2,7 +2,6 @@ import { Agent } from "agents";
 import type { SystemModelMessage } from "ai";
 import type { Env } from "./env";
 import { Db } from "./db/client";
-import { ConversationsRepo } from "./db/conversations";
 import { MessagesRepo } from "./db/messages";
 import { isPro } from "./config";
 import { resolveAgentConfig } from "./settings-loader";
@@ -19,6 +18,8 @@ import { formatLlmError } from "./llm/errorDetail";
 import { runLlmTurn } from "./llm/runTurn";
 import { costOfUsage } from "./pricing";
 import type { ChannelId } from "./channels/shared";
+import { ConversationsRepo, OWNER_TAKEOVER_MS } from "./db/conversations";
+import { notifyOwner } from "./tools/handoffHuman";
 import { maskTelegramToken, unmaskTelegramToken } from "./telegramFiles";
 
 export interface SupportAgentState {
@@ -75,10 +76,26 @@ export class SupportAgent extends Agent<Env, SupportAgentState> {
       conversationId: conv.id,
     });
 
-    // Owner intervened → pause the bot, do NOT process this as user input
+    // Owner intervened → sliding 20-min cap from THIS message. Do not treat
+    // it as customer input and do not arm the alarm. Later owner messages
+    // extend the window; silence past the cap lets the bot resume. Notify
+    // once when takeover starts — not on every echo (that is spam).
     if (payload.isOwnerMessage) {
-      const pausedUntil = Date.now() + 60 * 60 * 1000;
-      await convs.setPausedUntil(conv.id, pausedUntil);
+      const alreadyPaused = await convs.isPaused(conv.id);
+      await convs.setPausedUntil(conv.id, Date.now() + OWNER_TAKEOVER_MS);
+      if (!alreadyPaused) {
+        const inbox = `${this.env.DASHBOARD_BASE_URL || ""}/admin`;
+        await notifyOwner(this.env, {
+          reason: "dueño en el chat",
+          summary:
+            "El bot se pausó 20 minutos. Si sigues escribiendo se extiende; si no contestas, el bot vuelve solo.",
+          ticketId: conv.id,
+          text:
+            `⏸ Tomaste este chat. El bot se calla 20 minutos.\n` +
+            `Si sigues escribiendo, se extiende. Si no contestas, el bot vuelve solo.\n\n` +
+            `Ver: ${inbox}`,
+        }).catch((e) => console.warn("[ingest] takeover notify failed:", e));
+      }
       return { acknowledged: true };
     }
 

--- a/src/db/conversations.ts
+++ b/src/db/conversations.ts
@@ -16,6 +16,13 @@ function makeConvId(channel: string, channelUserId: string): string {
   return `${channel}:${channelUserId}`;
 }
 
+/**
+ * Owner-takeover window: 20 minutes from the last owner message.
+ * Later owner messages slide the window forward; silence past the cap
+ * lets the bot resume. Not unbounded — echoes cannot stack hours of pause.
+ */
+export const OWNER_TAKEOVER_MS = 20 * 60 * 1000;
+
 export class ConversationsRepo {
   constructor(private readonly db: Db) {}
 

--- a/src/tools/handoffHuman.ts
+++ b/src/tools/handoffHuman.ts
@@ -65,6 +65,8 @@ interface HandoffNotice {
   reason: string;
   summary: string;
   ticketId: string;
+  /** Override Telegram copy. Default is the ticket template. */
+  text?: string;
 }
 
 /**
@@ -95,6 +97,9 @@ export function handoffNotifyStatus(env: Env): { ok: boolean; channels: string[]
  */
 export async function notifyOwner(env: Env, notice: HandoffNotice): Promise<void> {
   const ticketUrl = `${env.DASHBOARD_BASE_URL}/admin/tickets`;
+  const telegramText =
+    notice.text ??
+    `🚨 Nuevo ticket [${notice.reason}]\n${notice.summary}\n\nVer: ${ticketUrl}`;
 
   // El SID de la plantilla puede venir del secret O del setting que escribe el
   // setup del panel. Se resuelve ANTES del guard: si vive solo en settings, el
@@ -134,8 +139,7 @@ export async function notifyOwner(env: Env, notice: HandoffNotice): Promise<void
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             chat_id: env.OWNER_TELEGRAM_CHAT_ID,
-            text:
-              `🚨 Nuevo ticket [${notice.reason}]\n${notice.summary}\n\nVer: ${ticketUrl}`,
+            text: telegramText,
           }),
         },
       );

--- a/test/admin/inbox.test.ts
+++ b/test/admin/inbox.test.ts
@@ -178,6 +178,10 @@ describe("inbox — pause / resume", () => {
     expect(res.status).toBe(200);
     expect(await res.text()).toContain("bot pausado");
     expect(await convs.isPaused(conv.id)).toBe(true);
+    const fresh = await convs.getById(conv.id);
+    const remaining = (fresh?.paused_until ?? 0) - Date.now();
+    expect(remaining).toBeGreaterThan(19 * 60 * 1000);
+    expect(remaining).toBeLessThanOrEqual(20 * 60 * 1000);
   });
 
   it("resume clears the pause and redirects back into the inbox", async () => {

--- a/test/agent.takeover.test.ts
+++ b/test/agent.takeover.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("agents", () => ({
+  Agent: class {
+    ctx: any;
+    env: any;
+    state: any;
+    constructor(ctx: any, env: any) {
+      this.ctx = ctx;
+      this.env = env;
+    }
+    setState(s: any) {
+      this.state = s;
+    }
+    sql(..._args: any[]) {
+      return undefined;
+    }
+  },
+}));
+
+const notifyOwnerMock = vi.fn(async (..._args: unknown[]) => {});
+vi.mock("../src/tools/handoffHuman", () => ({
+  notifyOwner: (...args: unknown[]) => notifyOwnerMock(...args),
+}));
+
+import { SupportAgent } from "../src/agent";
+import { ConversationsRepo, OWNER_TAKEOVER_MS } from "../src/db/conversations";
+import { SettingsRepo } from "../src/db/settings";
+
+function stubSettings() {
+  vi.spyOn(SettingsRepo.prototype, "all").mockResolvedValue({});
+}
+
+function makeAgent() {
+  const storage = { setAlarm: vi.fn(), getAlarm: vi.fn() };
+  const env: any = {
+    DB: {},
+    BOT_TIER: "free",
+    BOT_LANGUAGE: "es",
+    BUFFER_SECONDS: "8",
+    BOT_NAME: "TestBot",
+    BUSINESS_NAME: "TestCo",
+    DASHBOARD_BASE_URL: "https://dash.test",
+  };
+  const agent: any = new (SupportAgent as any)({ storage }, env);
+  agent.setState({
+    conversationId: "conv-1",
+    channel: "telegram",
+    channelUserId: "u1",
+    pendingMessages: [],
+    lastAlarmAt: 0,
+    lastUserLang: "es",
+    toolCallsInLast2Turns: 0,
+    lastSearchKbScore: 1,
+    imageRetryCount: 0,
+  });
+  return { agent, storage };
+}
+
+function stubConversations() {
+  let pausedUntil: number | null = null;
+  vi.spyOn(ConversationsRepo.prototype, "getOrCreate").mockResolvedValue({
+    id: "conv-1",
+    paused_until: null,
+  } as any);
+  vi.spyOn(ConversationsRepo.prototype, "isPaused").mockImplementation(async () => {
+    return pausedUntil != null && pausedUntil > Date.now();
+  });
+  const setPausedUntil = vi
+    .spyOn(ConversationsRepo.prototype, "setPausedUntil")
+    .mockImplementation(async (_id: string, until: number | null) => {
+      pausedUntil = until;
+    });
+  return {
+    setPausedUntil,
+    expire: () => {
+      pausedUntil = Date.now() - 1;
+    },
+    getPausedUntil: () => pausedUntil,
+  };
+}
+
+describe("SupportAgent.ingest — owner takeover cap", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    notifyOwnerMock.mockClear();
+    stubSettings();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("first owner message pauses 20 minutes and notifies once", async () => {
+    const { agent, storage } = makeAgent();
+    const convs = stubConversations();
+    const before = Date.now();
+
+    await agent.ingest({
+      channel: "telegram",
+      channelUserId: "u1",
+      text: "yo lo atiendo",
+      isOwnerMessage: true,
+    });
+
+    expect(convs.setPausedUntil).toHaveBeenCalledTimes(1);
+    const until = convs.setPausedUntil.mock.calls[0][1] as number;
+    expect(until).toBeGreaterThanOrEqual(before + OWNER_TAKEOVER_MS);
+    expect(until).toBeLessThanOrEqual(Date.now() + OWNER_TAKEOVER_MS);
+    expect(until - before).toBeLessThan(60 * 60 * 1000);
+    expect(notifyOwnerMock).toHaveBeenCalledTimes(1);
+    const notice = notifyOwnerMock.mock.calls[0][1] as { reason: string; text?: string };
+    expect(notice.reason).toBe("dueño en el chat");
+    expect(notice.text).toContain("20 minutos");
+    expect(storage.setAlarm).not.toHaveBeenCalled();
+    expect(agent.state.pendingMessages).toHaveLength(0);
+  });
+
+  it("later owner messages extend the 20-min window without a second notify", async () => {
+    const { agent, storage } = makeAgent();
+    const convs = stubConversations();
+
+    await agent.ingest({
+      channel: "telegram",
+      channelUserId: "u1",
+      text: "echo 1",
+      isOwnerMessage: true,
+    });
+    const firstUntil = convs.getPausedUntil() ?? 0;
+
+    await agent.ingest({
+      channel: "telegram",
+      channelUserId: "u1",
+      text: "echo 2",
+      isOwnerMessage: true,
+    });
+
+    expect(convs.setPausedUntil).toHaveBeenCalledTimes(2);
+    const secondUntil = convs.getPausedUntil() ?? 0;
+    expect(secondUntil).toBeGreaterThanOrEqual(firstUntil);
+    expect(secondUntil - Date.now()).toBeLessThanOrEqual(OWNER_TAKEOVER_MS);
+    expect(notifyOwnerMock).toHaveBeenCalledTimes(1);
+    expect(storage.setAlarm).not.toHaveBeenCalled();
+  });
+
+  it("customer messages while paused do not arm the alarm", async () => {
+    const { agent, storage } = makeAgent();
+    stubConversations();
+
+    await agent.ingest({
+      channel: "telegram",
+      channelUserId: "u1",
+      isOwnerMessage: true,
+    });
+    await agent.ingest({
+      channel: "telegram",
+      channelUserId: "u1",
+      text: "hola, ¿siguen ahí?",
+    });
+
+    expect(storage.setAlarm).not.toHaveBeenCalled();
+    expect(agent.state.pendingMessages).toHaveLength(0);
+  });
+
+  it("after the cap expires, a customer message wakes the bot", async () => {
+    const { agent, storage } = makeAgent();
+    const convs = stubConversations();
+
+    await agent.ingest({
+      channel: "telegram",
+      channelUserId: "u1",
+      isOwnerMessage: true,
+    });
+    convs.expire();
+
+    await agent.ingest({
+      channel: "telegram",
+      channelUserId: "u1",
+      text: "¿hay alguien?",
+    });
+
+    expect(storage.setAlarm).toHaveBeenCalled();
+    expect(agent.state.pendingMessages).toHaveLength(1);
+    expect(agent.state.pendingMessages[0].text).toBe("¿hay alguien?");
+  });
+
+  it("a new owner message after expiry is a new takeover and notifies again", async () => {
+    const { agent } = makeAgent();
+    const convs = stubConversations();
+
+    await agent.ingest({
+      channel: "telegram",
+      channelUserId: "u1",
+      isOwnerMessage: true,
+    });
+    expect(notifyOwnerMock).toHaveBeenCalledTimes(1);
+    convs.expire();
+
+    await agent.ingest({
+      channel: "telegram",
+      channelUserId: "u1",
+      text: "vuelvo a entrar",
+      isOwnerMessage: true,
+    });
+    expect(notifyOwnerMock).toHaveBeenCalledTimes(2);
+    expect(convs.setPausedUntil).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/db/conversations.test.ts
+++ b/test/db/conversations.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { createTestMiniflare } from "../helpers/miniflareSetup";
 import { Db } from "../../src/db/client";
-import { ConversationsRepo } from "../../src/db/conversations";
+import { ConversationsRepo, OWNER_TAKEOVER_MS } from "../../src/db/conversations";
 
 let repo: ConversationsRepo;
 
@@ -38,5 +38,10 @@ describe("ConversationsRepo", () => {
     const conv = await repo.getOrCreate("telegram", "user_999");
     await repo.setPausedUntil(conv.id, Date.now() - 60_000);
     expect(await repo.isPaused(conv.id)).toBe(false);
+  });
+
+  it("OWNER_TAKEOVER_MS is a 20-minute hard cap, not an hour", () => {
+    expect(OWNER_TAKEOVER_MS).toBe(20 * 60 * 1000);
+    expect(OWNER_TAKEOVER_MS).toBeLessThan(60 * 60 * 1000);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Qué cambia
La pausa cuando el dueño entra al chat (mensaje `isOwnerMessage` o reply/pausa desde el inbox) ahora dura **20 minutos desde el último mensaje del dueño**, no 60. Avisa al dueño **una sola vez** al empezar el takeover. Si el dueño sigue escribiendo, la ventana se extiende otros 20 min; si se queda callado, el bot vuelve solo.

## Por qué
Ticket de soporte **#6A0B7E** (Leonardo Sanchez, Mariscos El Jaiboncito). El dueño mandaba un mensaje (echo de coexistencia), el bot se callaba 60 min, y cada echo nuevo **rearmaba** otros 60 min. En producción una clienta esperó ~1h40 sin respuesta de nadie.

Hallazgos 1 y 2 del mismo ticket (botones YCloud + retry de `serveYCloudMedia` ante 502) **no están en este repo público**: no existen `src/channels/ycloud.ts`, `BUTTON_CHANNELS` ni overlay Forja+. No se inventó código de overlay. Quedan en el template Forja+.

El hallazgo 3 (pausa sin techo ni aviso) sí vive en `src/agent.ts` de este `main`.

## Cómo lo verificaste
- [x] `pnpm test` — 78 files / 553 tests OK (incluye `test/agent.takeover.test.ts`)
- [x] `pnpm typecheck` limpio
- [x] Tests nuevos: primer aviso, extensión sin segundo aviso, silencio del bot mientras dura la pausa, el cliente despierta al bot al expirar, nuevo takeover tras expirar avisa de nuevo
- [x] El inbox `/pause` queda en ~20 min (`test/admin/inbox.test.ts`)

## Checklist
- [x] No toqué la carpeta `member/`
- [x] El PR es de un solo tema (pausa de takeover)
- [x] No hay secrets ni API keys
- [x] Sin merge, sin publish a npm

## Comportamiento
- Cap duro: `OWNER_TAKEOVER_MS = 20 * 60 * 1000` (compartido por el agente y el inbox)
- Aviso único vía `notifyOwner` (mismos canales que el handoff: Telegram / WhatsApp HSM / email)
- Un echo posterior **no** reinicia una pausa infinita: solo corre la ventana de 20 min
- Tras el silencio, `isPaused` ya evaluaba el tiempo; el siguiente mensaje del cliente arma el alarm otra vez
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1f6afd7-971d-4541-be66-222f860d0cdf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1f6afd7-971d-4541-be66-222f860d0cdf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Owner takeover pauses now last 20 minutes.
  * Additional owner messages extend the pause without sending duplicate notifications.
  * Custom handoff messages are supported.

* **Bug Fixes**
  * Customer messages no longer prematurely resume conversations during an active owner takeover.
  * The bot correctly resumes after the takeover window expires.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->