### PR TITLE
fix(kb): request returnMetadata on Vectorize query

### DIFF
--- a/src/tools/searchKb.ts
+++ b/src/tools/searchKb.ts
@@ -24,7 +24,13 @@ export function searchKbTool(env: Env) {
         if (!Array.isArray(vec)) {
           return { error: "transient" as const, message: "embedding shape unexpected" };
         }
-        const matches = await env.KB.query(vec, { topK: 5 });
+        // returnMetadata defaults to "none" — without it Vectorize returns a
+        // correct score but title/content are ALWAYS empty. The model sees a
+        // "match" with a decent score but no actual text, and (correctly,
+        // per its anti-hallucination instructions) refuses to use it. This
+        // looks like a confidence-threshold problem but never is — the KB
+        // content just never made it back from Vectorize in the first place.
+        const matches = await env.KB.query(vec, { topK: 5, returnMetadata: "all" });
         const results: SearchKbResult[] = (matches.matches ?? []).map((m: any) => ({
           title: (m.metadata?.title as string) ?? "",
           content: (m.metadata?.content as string) ?? "",

--- a/test/tools/searchKb.test.ts
+++ b/test/tools/searchKb.test.ts
@@ -18,6 +18,18 @@ describe("searchKbTool", () => {
     expect(result.results[0].score).toBe(0.91);
   });
 
+  it("requests returnMetadata — without it Vectorize returns a real score but empty title/content", async () => {
+    const query = vi.fn(async () => ({ matches: [] }));
+    const fakeEnv = {
+      AI: { run: vi.fn(async () => ({ data: [[0.1, 0.2, 0.3]] })) },
+      KB: { query },
+    } as any;
+    const tool = searchKbTool(fakeEnv);
+    const execute = tool.execute as (input: { query: string }) => Promise<any>;
+    await execute({ query: "como embebo wall" });
+    expect(query).toHaveBeenCalledWith([0.1, 0.2, 0.3], { topK: 5, returnMetadata: "all" });
+  });
+
   it("returns empty results when KB throws", async () => {
     const fakeEnv = {
       AI: { run: vi.fn(async () => ({ data: [[0.1, 0.2]] })) },


### PR DESCRIPTION
## Qué cambia
`env.KB.query()` in `searchKb.ts` now passes `returnMetadata: "all"`.

## Por qué
Without it, Vectorize returns a correct similarity score but `title`/`content` in the metadata are **always empty**. The model sees a "match" with a decent score but no actual text, and — correctly, per its anti-hallucination instructions — refuses to use it. This reads like a confidence-threshold problem but never is; the KB content just never made it back from Vectorize.

Found while debugging a bot that kept saying "I can't find the rubric in the knowledge base" even after loading the exact document and getting a healthy similarity score (0.51) on an on-topic query. Root-caused it by logging the raw Vectorize response — score present, metadata absent.

## Cómo lo probaste
- [x] `pnpm typecheck` limpio
- [x] `pnpm test test/tools/searchKb.test.ts` — 3/3 (1 nuevo, asserts `returnMetadata: "all"` is passed)
- [ ] `pnpm test` (full suite) — heads up: on this machine `createTestMiniflare()` currently times out on a clean `upstream/main` checkout too (verified with zero changes applied), so I couldn't get a clean full-suite signal either way. Unrelated to this 1-line change — happy to help track that down separately if useful.
- [x] probado contra un bot real (producción, con una rúbrica real cargada — confirmado que la retroalimentación ahora sí usa el contenido de la KB)

## Checklist
- [x] No toqué la carpeta `member/`
- [x] El PR es de un solo tema (enfocado y chico)
- [x] Revisé el diff yo mismo antes de abrirlo
- [x] No hay secrets ni API keys en el código

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Knowledge-base search results now include the associated title and content metadata alongside relevance scores, improving the completeness of returned results.

- **Tests**
  - Added coverage to verify that searches request and return complete result metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->