### PR TITLE
feat(telegram): render markdown as real bold/italic/underline instead of stripping it

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -1,5 +1,6 @@
 import type { ChannelAdapter, IncomingMessage, OutgoingReply } from "./shared";
 import type { Env } from "../env";
+import { toTelegramHtml, hasBalancedTags } from "../replies/format";
 
 const TG_API = "https://api.telegram.org/bot";
 
@@ -79,11 +80,46 @@ export const telegramAdapter: ChannelAdapter = {
       }).catch(() => {});
       const delay = i === 0 ? 0 : reply.interChunkDelayMs ?? 1000;
       if (delay > 0) await new Promise((r) => setTimeout(r, delay));
-      await fetch(`${TG_API}${token}/sendMessage`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ chat_id: reply.channelUserId, text: reply.chunks[i] }),
-      });
+      // Sin parse_mode, Telegram muestra "**negrita**" literal en vez de
+      // renderizarla — el modelo escribe markdown, pero nadie lo traduce.
+      // Ojo: un parse_mode:"HTML" inválido no lanza, solo devuelve 400 — si
+      // no se revisa `res.ok`, el mensaje se pierde en silencio. Por eso:
+      // (1) valida el balanceo de tags ANTES de mandar (hasBalancedTags),
+      // (2) si Telegram igual lo rechaza, reintenta UNA vez en texto plano.
+      // El alumno/cliente nunca se queda sin respuesta por un HTML raro.
+      const html = toTelegramHtml(reply.chunks[i]);
+      const sendOnce = (body: Record<string, unknown>) =>
+        fetch(`${TG_API}${token}/sendMessage`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+
+      let res: Response;
+      if (hasBalancedTags(html)) {
+        res = await sendOnce({ chat_id: reply.channelUserId, text: html, parse_mode: "HTML" });
+      } else {
+        console.error("[telegram] HTML sin balancear, se manda como texto plano", {
+          preview: html.slice(0, 120),
+        });
+        res = await sendOnce({ chat_id: reply.channelUserId, text: reply.chunks[i] });
+      }
+
+      if (!res.ok) {
+        const errBody = await res.text().catch(() => "");
+        console.error(
+          `[telegram] sendMessage falló (status ${res.status}) con HTML, reintentando en texto plano`,
+          errBody,
+        );
+        const retry = await sendOnce({ chat_id: reply.channelUserId, text: reply.chunks[i] });
+        if (!retry.ok) {
+          const retryErrBody = await retry.text().catch(() => "");
+          console.error(
+            `[telegram] sendMessage falló otra vez en texto plano (status ${retry.status})`,
+            retryErrBody,
+          );
+        }
+      }
     }
   },
 

--- a/src/replies/format.ts
+++ b/src/replies/format.ts
@@ -1,0 +1,80 @@
+/**
+ * Convierte el markdown ligero que el modelo genera (negritas **, cursiva
+ * *_o_*, subrayado __) a HTML válido para el `parse_mode: "HTML"` de la
+ * Bot API de Telegram.
+ *
+ * Sin esto, `sendMessage` manda el texto tal cual y Telegram lo muestra
+ * literal — el alumno ve los asteriscos en vez de negritas. Reportado
+ * 2026-08-27: el modelo escribía `**bold**` correctamente, pero nadie lo
+ * traducía a algo que Telegram supiera renderizar.
+ *
+ * Solo cubre lo que el prompt de este bot realmente usa (negrita, cursiva,
+ * subrayado, y sus combinaciones *** / ___) — no es un parser de markdown
+ * completo.
+ *
+ * DISEÑO — una sola pasada, no 4 reemplazos encadenados. Revisión de Opus
+ * 2026-09-03 encontró que 4 `.replace()` secuenciales (negrita, luego
+ * subrayado, luego cursiva ×2) se estorban entre sí: "**x**" seguido de un
+ * tercer asterisco ("***x***", que el prompt SÍ produce cuando pide "muy
+ * importante") deja un asterisco suelto que la pasada de cursiva empareja
+ * con el CIERRE de una etiqueta ya insertada, generando HTML mal anidado
+ * (`<b><i>x</b></i>`) — Telegram responde 400 y el mensaje se pierde
+ * COMPLETO y en silencio. Una sola regex con alternancia (probada en orden,
+ * la más específica primero) evita que un paso reprocese lo que insertó
+ * otro. Los límites `(?=\S)…(?<=\S)` (estilo CommonMark: nada de espacio
+ * pegado al marcador) evitan que viñetas ("* Punto uno") o aritmética
+ * ("2*4") se lean como énfasis.
+ */
+const HTML_ESCAPES: Record<string, string> = { "&": "&amp;", "<": "&lt;", ">": "&gt;" };
+
+const MARK_RE =
+  /\*\*\*(?=\S)([^*\n]+?)(?<=\S)\*\*\*|___(?=\S)([^_\n]+?)(?<=\S)___|\*\*(?=\S)([^*\n]+?)(?<=\S)\*\*|__(?=\S)([^_\n]+?)(?<=\S)__|\*(?=\S)([^*\n]+?)(?<=\S)\*|(?<![\w])_(?=\S)([^_\n]+?)(?<=\S)_(?![\w])/g;
+
+export function toTelegramHtml(text: string): string {
+  // 1) Escapa entidades HTML del texto ORIGINAL antes de insertar las
+  //    etiquetas propias — así un "<" o "&" que escriba el alumno/modelo no
+  //    rompe el parser de Telegram ni se confunde con nuestras tags reales.
+  const escaped = text.replace(/[&<>]/g, (c) => HTML_ESCAPES[c]);
+
+  // 2) Una sola pasada: cada alternativa se prueba en orden en cada
+  //    posición, así "***x***" se resuelve como negrita+cursiva ANTES de
+  //    que la alternativa de "**" tenga oportunidad de partirlo a medias.
+  //    Un marcador sin pareja (viñeta, aritmética, markdown cruzado tipo
+  //    "**a _b** c_") simplemente no matchea y queda como texto literal —
+  //    nunca produce una tag sin cerrar.
+  return escaped.replace(
+    MARK_RE,
+    (_m, boldItalic, underlineItalic, bold, underline, italicStar, italicUnderscore) => {
+      if (boldItalic !== undefined) return `<b><i>${boldItalic}</i></b>`;
+      if (underlineItalic !== undefined) return `<u><i>${underlineItalic}</i></u>`;
+      if (bold !== undefined) return `<b>${bold}</b>`;
+      if (underline !== undefined) return `<u>${underline}</u>`;
+      if (italicStar !== undefined) return `<i>${italicStar}</i>`;
+      return `<i>${italicUnderscore}</i>`;
+    },
+  );
+}
+
+/**
+ * Verifica que el HTML que vamos a mandarle a Telegram tenga las tags b/i/u
+ * balanceadas y bien anidadas (sin cruces tipo "<b>x<i>y</b>z</i>"). Es un
+ * chequeo barato — no valida HTML en general, solo las 3 tags que nosotros
+ * mismos insertamos — pero es la red de seguridad antes de mandar: si algo
+ * se nos escapó (markdown que no anticipamos), lo detectamos ANTES de que
+ * Telegram lo rechace con un 400 silencioso, y channels/telegram.ts cae a
+ * texto plano en vez de perder el mensaje.
+ */
+export function hasBalancedTags(html: string): boolean {
+  const stack: string[] = [];
+  const tagRe = /<(\/?)([biu])>/g;
+  let m: RegExpExecArray | null;
+  while ((m = tagRe.exec(html))) {
+    const [, closing, tag] = m;
+    if (!closing) {
+      stack.push(tag);
+    } else if (stack.pop() !== tag) {
+      return false;
+    }
+  }
+  return stack.length === 0;
+}

--- a/test/channels/telegram.test.ts
+++ b/test/channels/telegram.test.ts
@@ -120,3 +120,49 @@ describe("resolveTelegramFileUrl", () => {
     expect(url).toBeNull();
   });
 });
+
+describe("telegramAdapter.sendReply", () => {
+  it("sends parse_mode HTML with markdown converted to tags", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    await telegramAdapter.sendReply(
+      { channel: "telegram", channelUserId: "555", chunks: ["**Ojo:** te falta __la conclusión__."] },
+      env,
+    );
+
+    const sendMessageCall = fetchSpy.mock.calls.find(([url]) =>
+      String(url).includes("/sendMessage"),
+    );
+    expect(sendMessageCall).toBeDefined();
+    const body = JSON.parse(String(sendMessageCall![1]?.body));
+    expect(body.parse_mode).toBe("HTML");
+    expect(body.text).toBe("<b>Ojo:</b> te falta <u>la conclusión</u>.");
+  });
+
+  it("reintenta en texto plano si Telegram rechaza el HTML (400)", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 })) // typing
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: false, description: "can't parse entities" }), {
+          status: 400,
+        }),
+      ) // sendMessage con HTML falla
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 })); // retry en texto plano
+
+    await telegramAdapter.sendReply(
+      { channel: "telegram", channelUserId: "555", chunks: ["**algo**"] },
+      env,
+    );
+
+    const sendMessageCalls = fetchSpy.mock.calls.filter(([url]) =>
+      String(url).includes("/sendMessage"),
+    );
+    expect(sendMessageCalls).toHaveLength(2);
+    const retryBody = JSON.parse(String(sendMessageCalls[1][1]?.body));
+    expect(retryBody.parse_mode).toBeUndefined();
+    expect(retryBody.text).toBe("**algo**");
+  });
+});

--- a/test/replies/format.test.ts
+++ b/test/replies/format.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { toTelegramHtml, hasBalancedTags } from "../../src/replies/format";
+
+describe("toTelegramHtml", () => {
+  it("converts **bold** to <b>", () => {
+    expect(toTelegramHtml("esto es **importante**")).toBe("esto es <b>importante</b>");
+  });
+
+  it("converts __underline__ to <u>", () => {
+    expect(toTelegramHtml("no puede faltar __esto__")).toBe("no puede faltar <u>esto</u>");
+  });
+
+  it("converts *italic* and _italic_ to <i>", () => {
+    expect(toTelegramHtml("un *matiz* y otro _matiz_")).toBe("un <i>matiz</i> y otro <i>matiz</i>");
+  });
+
+  it("handles bold and underline together without leaking asterisks", () => {
+    expect(toTelegramHtml("**Ojo:** falta __la conclusión__.")).toBe(
+      "<b>Ojo:</b> falta <u>la conclusión</u>.",
+    );
+  });
+
+  it("escapes raw HTML special chars from the model/user before adding tags", () => {
+    expect(toTelegramHtml("5 < 10 & **ok**")).toBe("5 &lt; 10 &amp; <b>ok</b>");
+  });
+
+  it("leaves plain text without markers untouched (aside from HTML escaping)", () => {
+    expect(toTelegramHtml("hola, todo normal")).toBe("hola, todo normal");
+  });
+
+  it("does not treat an underscore inside a word as italic", () => {
+    expect(toTelegramHtml("nombre_de_variable sin cambios")).toBe(
+      "nombre_de_variable sin cambios",
+    );
+  });
+
+  // Casos encontrados por la revisión de Opus (2026-09-03): con las 4 pasadas
+  // secuenciales viejas, estos producían HTML mal anidado → Telegram
+  // rechazaba el mensaje ENTERO con 400 y se perdía en silencio.
+  describe("regresión — HTML mal anidado (revisión Opus 2026-09-03)", () => {
+    it("***texto*** (negrita+cursiva) no deja un asterisco suelto", () => {
+      const out = toTelegramHtml("esto es ***muy importante***");
+      expect(out).toBe("esto es <b><i>muy importante</i></b>");
+      expect(hasBalancedTags(out)).toBe(true);
+    });
+
+    it("___texto___ (subrayado+cursiva) no deja un guion bajo suelto", () => {
+      const out = toTelegramHtml("___esto no puedes dejarlo pasar___");
+      expect(out).toBe("<u><i>esto no puedes dejarlo pasar</i></u>");
+      expect(hasBalancedTags(out)).toBe(true);
+    });
+
+    it("marcadores cruzados producen HTML válido (aunque no el énfasis 'intentado')", () => {
+      const out = toTelegramHtml("**Nota _importante** sigue_");
+      expect(hasBalancedTags(out)).toBe(true);
+    });
+
+    it("otro caso de marcadores cruzados también queda balanceado", () => {
+      const out = toTelegramHtml("**bold _mixed** italic_");
+      expect(hasBalancedTags(out)).toBe(true);
+    });
+  });
+
+  describe("no confunde viñetas ni aritmética con énfasis (revisión Opus 2026-09-03)", () => {
+    it("una viñeta con '* ' al inicio de línea queda intacta", () => {
+      const out = toTelegramHtml("* Punto uno\n* Punto dos\n* Punto tres");
+      expect(out).toBe("* Punto uno\n* Punto dos\n* Punto tres");
+    });
+
+    it("aritmética con espacios alrededor del asterisco queda intacta", () => {
+      expect(toTelegramHtml("5 * 3 y 4 * 2")).toBe("5 * 3 y 4 * 2");
+    });
+  });
+});
+
+describe("hasBalancedTags", () => {
+  it("true para texto sin tags", () => {
+    expect(hasBalancedTags("hola")).toBe(true);
+  });
+
+  it("true para tags bien anidadas", () => {
+    expect(hasBalancedTags("<b>hola <i>mundo</i></b>")).toBe(true);
+  });
+
+  it("false para una tag sin cerrar", () => {
+    expect(hasBalancedTags("<b>hola")).toBe(false);
+  });
+
+  it("false para tags cruzadas", () => {
+    expect(hasBalancedTags("<b>hola <i>mundo</b></i>")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Qué cambia
Adds `src/replies/format.ts` (`toTelegramHtml` + `hasBalancedTags`) and wires it into `telegramAdapter.sendReply` with `parse_mode: "HTML"`.

## Por qué
`sendMessage` never sets `parse_mode`, so Telegram shows the model's `**bold**`/`_italic_` literally — asterisks and underscores on screen, no formatting. I know #11 addressed this by having the model avoid markdown entirely (plain text); this is an alternative that renders it instead, since real emphasis reads noticeably better than a wall of unformatted text, especially for longer structured replies (checklists, step-by-step feedback, etc.). Happy to close this in favor of the existing approach if plain-text-only is the preferred direction — just wanted to offer the option since I'd already built and tested it.

Two things that matter here, both handled:

1. **Naive sequential regex replaces break on `***text***` / `___text___`.** A bold-pass followed by an underline-pass followed by an italic-pass will, on a triple marker, pair a leftover asterisk with an *already-inserted* tag's closer — invalid nested HTML (`<b><i>x</b></i>`). `toTelegramHtml` uses one alternation regex instead (tried in order, most specific first: `***`, `___`, `**`, `__`, `*`, `_`), so no pass ever reprocesses another's output. CommonMark-style boundaries (`\S` hugging the marker) also keep bullet lists (`* Point one`) and inline math (`2*4`) from being misread as emphasis.
2. **`parse_mode: "HTML"` with invalid markup doesn't throw** — Telegram just returns 400, and if nobody checks `res.ok` the message silently vanishes. This was the only channel adapter in the repo that didn't check `res.ok` (whatsapp/meta/kapso/ycloud/zernio all do). Added a cheap tag-balance check before sending (`hasBalancedTags`) plus a `res.ok` check with a plain-text retry on failure, so a customer never ends up with nothing.

## Cómo lo probaste
- [x] `pnpm typecheck` limpio
- [x] `pnpm test test/replies/format.test.ts test/channels/telegram.test.ts` — 24/24 (19 nuevos)
- [ ] `pnpm test` (full suite) — same pre-existing `createTestMiniflare()` timeout as in #62/#63, confirmed on a clean `upstream/main` checkout too
- [x] probado contra un bot real en producción (varios mensajes con negrita/cursiva/subrayado, renderizando correctamente en Telegram)

## Checklist
- [x] No toqué la carpeta `member/`
- [x] El PR es de un solo tema (formato de Telegram)
- [x] Revisé el diff yo mismo antes de abrirlo
- [x] No hay secrets ni API keys en el código

🤖 Generated with [Claude Code](https://claude.com/claude-code)